### PR TITLE
Use a static Info.plist file for macOS packages

### DIFF
--- a/package/Info.plist
+++ b/package/Info.plist
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>17D47</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>love</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>GameIcon</string>
+			<key>CFBundleTypeName</key>
+			<string>LÖVE Project</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.love2d.love-game</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Folder</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>fold</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>None</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>Document</string>
+			<key>CFBundleTypeName</key>
+			<string>Document</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>****</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>love</string>
+	<key>CFBundleIconFile</key>
+	<string>OS X AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>OS X AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>net.synthein.synthein</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Synthein</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>11.1</string>
+	<key>CFBundleSignature</key>
+	<string>LoVe</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>9C40b</string>
+	<key>DTPlatformVersion</key>
+	<string>GM</string>
+	<key>DTSDKBuild</key>
+	<string>17C76</string>
+	<key>DTSDKName</key>
+	<string>macosx10.13</string>
+	<key>DTXcode</key>
+	<string>0920</string>
+	<key>DTXcodeBuild</key>
+	<string>9C40b</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2006-2018 LÖVE Development Team</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<false/>
+</dict>
+</plist>

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -24,13 +24,9 @@ main () {
 	echo "Building MacOS package."
 	app_dir="${build_dir}/synthein.app"
 
-	cp -R "${cache_dir}/love.app" "$app_dir"
-	cd "$app_dir"
-
-	cp "$love_file" "Contents/Resources/"
-	sed -i -e 's/<string>org.love2d.love<\/string>/<string>net.synthein.synthein<\/string>/' Contents/Info.plist
-	sed -i -e 's/<string>LÖVE<\/string>/<string>Synthein<\/string>/' Contents/Info.plist
-	sed -i -e '98,126d' Contents/Info.plist
+	cp -aR "${cache_dir}/love.app/" "$app_dir"
+	cp "$love_file" "${app_dir}/Contents/Resources/"
+	cp "${root_dir}/package/Info.plist" "${app_dir}/Contents/"
 
 	cd "$build_dir"
 	zip -r "$build_file" synthein.app


### PR DESCRIPTION
Instead of using sed to modify the Info.plist file at build time, we can
just check the file into version control. The sed scripts broke between
releases of LOVE; hopefully this will be more resilient.