### PR TITLE
Make collision callbacks only take fixture parameters

### DIFF
--- a/src/world/shipparts/ai.lua
+++ b/src/world/shipparts/ai.lua
@@ -7,13 +7,13 @@ function AI:__create(team)
 	self.follow = true
 end
 
-function AI:getOrders(worldInfo, leader, body, bodyList)
+function AI:getOrders(worldInfo, leader, aiBody, bodyList)
 	local physics = worldInfo.physics
 	local teamHostility = worldInfo.teamHostility
-	local aiX, aiY = body:getPosition()
-	local aiAngle = body:getAngle()
-	local aiXV, aiYV = body:getLinearVelocity()
-	local aiAngleVol = body:getAngularVelocity()
+	local aiX, aiY = aiBody:getPosition()
+	local aiAngle = aiBody:getAngle()
+	local aiXV, aiYV = aiBody:getLinearVelocity()
+	local aiAngleVol = aiBody:getAngularVelocity()
 	local target, leaderX, leaderY, leaderMSq
 	local leaderFollow = false
 	if leader and self.follow then
@@ -33,7 +33,7 @@ function AI:getOrders(worldInfo, leader, body, bodyList)
 		if next(bodyList) ~= nil then
 			local targetMSq = nil
 			for body, fixtures in pairs(bodyList) do
-				object = body:getUserData()
+				local object = body:getUserData()
 				-- Look for core blocks.
 				if object and object.getTeam and
 				   teamHostility:test(self.team, object:getTeam()) then

--- a/src/world/shipparts/hull.lua
+++ b/src/world/shipparts/hull.lua
@@ -25,22 +25,17 @@ function Hull:__create(imagefunction, maxHealth)--, connectableSides)
 		imagefunction(x, y, angle)
 	end
 
-	function userData:collision(fixture, otherFixture, sqVelocity, pointVelocity)
+	function userData.collision(fixture, otherFixture, sqVelocity, pointVelocity)
 		local object = otherFixture:getUserData()
 		local _, _, mass, _ = otherFixture:getMassData()
 		local damage = math.floor(sqVelocity * mass / 40)
 		object:damage(otherFixture, damage)
-		local body = fixture:getBody()
-		local mult = -damage
-
-		if mult < -10 then mult = -10 end
-		mult = mult / 10
-		local xI, yI = unpack(pointVelocity)
 	end
 
 	function userData.damage(userData, fixture, damage)
 		local body = fixture:getBody()
-		local l = self.userData.location
+		local l = userData.location
+		local location
 		if body and l then
 			local partX, partY, angle = unpack(l)
 			local x, y = body:getWorldPoints(partX, partY)

--- a/src/world/shipparts/sensor.lua
+++ b/src/world/shipparts/sensor.lua
@@ -19,16 +19,16 @@ function Sensor:addFixtures(body, x, y)
 
 	local bodyList = self.bodyList
 	local userData = {
-		collision = function(object, fixtureA, fixtureB, sqV, aL)
-			local body = fixtureB:getBody()
-			if not bodyList[body] then bodyList[body] = {} end
-			bodyList[body][fixtureB] = true
+		collision = function(fixtureA, fixtureB, sqV, aL)
+			local bodyB = fixtureB:getBody()
+			if not bodyList[bodyB] then bodyList[bodyB] = {} end
+			bodyList[bodyB][fixtureB] = true
 		end,
 
-		endCollision = function(object, fixtureA, fixtureB, sqV, aL)
-			local body = fixtureB:getBody()
-			bodyList[body][fixtureB] = nil
-			if next(bodyList[body]) == nil then bodyList[body] = nil end
+		endCollision = function(fixtureA, fixtureB, sqV, aL)
+			local bodyB = fixtureB:getBody()
+			bodyList[bodyB][fixtureB] = nil
+			if next(bodyList[bodyB]) == nil then bodyList[bodyB] = nil end
 		end
 	}
 

--- a/src/world/shot.lua
+++ b/src/world/shot.lua
@@ -17,7 +17,17 @@ function Shot:__create(worldInfo, location, data, appendix)
 	self.fixture:setSensor(true)
 
 	PhysicsReferences.setFixtureType(self.fixture, "projectiles")
-	self.fixture:setUserData(self)
+	self.fixture:setUserData({
+		collision = function(fixture, otherFixture)
+			if self.timePassed and self.firstContact then
+				local object = otherFixture:getUserData()
+				object:damage(otherFixture, 1)
+				self:destroy()
+				self.firstContact = false --this is needed because of bullet body physics
+			end
+		end,
+		draw = Draw.createObjectDrawImageFunction("shot", .1, .5),
+	})
 
 	self.timer = Timer(5)
 	self.firstContact = true
@@ -40,15 +50,6 @@ function Shot:getSaveData(references)
 	return {self.timer:time()}
 end
 
-function Shot:collision(fixture, otherFixture)
-	if self.timePassed and self.firstContact then
-		local object = otherFixture:getUserData()
-		object:damage(otherFixture, 1)
-		self:destroy()
-		self.firstContact = false --this is needed because of bullet body physics
-	end
-end
-
 function Shot:update(dt)
 	self.timePassed = true
 	if self.timer:ready(dt) then
@@ -57,7 +58,5 @@ function Shot:update(dt)
 
 	return {}
 end
-
-Shot.draw = Draw.createObjectDrawImageFunction("shot", .1, .5)
 
 return Shot

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -79,11 +79,11 @@ function World.beginContact(fixtureA, fixtureB, coll)
 	local objectB = fixtureB:getUserData()
 
 	if aCategory <= bCategory then
-		objectA:collision(fixtureA, fixtureB, sqV, aL)
+		objectA.collision(fixtureA, fixtureB, sqV, aL)
 	end
 
 	if bCategory <= aCategory then
-		objectB:collision(fixtureB, fixtureA, sqV, bL)
+		objectB.collision(fixtureB, fixtureA, sqV, bL)
 	end
 end
 
@@ -97,11 +97,11 @@ function World.endContact(fixtureA, fixtureB, coll)
 	local objectB = fixtureB:getUserData()
 
 	if aCategory <= bCategory and objectA.endCollision then
-		objectA:endCollision(fixtureA, fixtureB)
+		objectA.endCollision(fixtureA, fixtureB)
 	end
 
 	if bCategory <= aCategory and objectB.endCollision  then
-		objectB:endCollision(fixtureB, fixtureA)
+		objectB.endCollision(fixtureB, fixtureA)
 	end
 end
 


### PR DESCRIPTION
Collision callbacks previously took a `self` parameter. This wasn't used
or needed anywhere, so it was removed. Collision callbacks now only work
with the fixtures involved in the collision. If they need access to
fields of the entity that's involved in the collision, they can use
closures.