### PR TITLE
Change world's event system to take a closure instead of a table

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -5,6 +5,7 @@ local PartRegistry = require("world/shipparts/partRegistry")
 local LocationTable = require("locationTable")
 local PhysicsReferences = require("world/physicsReferences")
 local Settings = require("settings")
+local Structure = require("world/structure")
 
 local lume = require("vendor/lume")
 
@@ -129,11 +130,9 @@ function Player:buttonpressed(source, button, debugmode)
 			end
 
 			if part and location then
-				-- TODO: Move this pattern to a function and write a unit test
-				-- for it.
-				location = LocationTable(unpack(location))
-				table.insert(self.world.info.events.create,
-							 {"structure", location, part})
+				self.world:createObject(function(worldInfo)
+					return (Structure(worldInfo, LocationTable(unpack(location)), part))
+				end)
 			end
 			self.menu = nil
 		end

--- a/src/world/missile.lua
+++ b/src/world/missile.lua
@@ -6,8 +6,6 @@ local vector = require("vector")
 local Missile = class(require("world/worldObjects"))
 
 function Missile:__create(worldInfo, location, data, appendix)
-	self.events = worldInfo.events
-
 	self.thrust = 10
 	self.torque = 0.2
 	self.body:setLinearVelocity(location[4], location[5])

--- a/src/world/shipparts/gun.lua
+++ b/src/world/shipparts/gun.lua
@@ -1,3 +1,4 @@
+local Shot = require("world/shot")
 local Timer = require("timer")
 
 local Gun = class()
@@ -29,7 +30,7 @@ function Gun:update(inputs, location)
 			if not getPart(location, {0, 1}) then
 				self.charged = false
 				-- Spawn Shot
-				return {"shot", {0, 0, 1}}
+				return {Shot, {0, 0, 1}}
 			end
 		end
 	end

--- a/src/world/shipparts/hull.lua
+++ b/src/world/shipparts/hull.lua
@@ -1,5 +1,6 @@
 local PhysicsReferences = require("world/physicsReferences")
 local Location = require("world/location")
+local Particles = require("world/particles")
 
 local Hull = class()
 
@@ -83,7 +84,7 @@ end
 
 function Hull:update()
 	if self.isDestroyed then
-		return {"particles", {0, 0, 1}}, true
+		return {Particles, {0, 0, 1}}, true
 	end
 end
 


### PR DESCRIPTION
The goal of this change is to put the responsibility of creating objects
on the code that wants to put a new object in the world. world.lua still
calls the code to create objects at the correct time and is still
responsible for inserting objects into world.objects. However, if there
is an error in the code that generates a "create" event, it now looks
like that code's fault instead of the world's fault. This makes it
easier to debug errors in create events.

Here is an example. Let's modify structure.lua so that it generates an
invalid structure. Instead of a valid location, we'll pass in a number.

	diff --git a/src/world/structure.lua b/src/world/structure.lua
	index 985ea8a..985f0fe 100644
	--- a/src/world/structure.lua
	+++ b/src/world/structure.lua
	@@ -343,7 +343,7 @@ function Structure:disconnectPart(location, isDestroyed)

			end

	-               local newStructure = {"structure", location, {parts = structure}}
	+               local newStructure = {"structure", 0, {parts = structure}}
			table.insert(self.events.create, newStructure)
		end
	 end

Now we will run the game and go over that code path. We get the
following stack trace:

	Error: world/worldObjects.lua:7: attempt to index local 'location' (a number value)
	stack traceback:
		[string "boot.lua"]:777: in function '__index'
		world/worldObjects.lua:7: in function '__create'
		class.lua:5: in function 'parent'
		class.lua:4: in function 'objectClass'
		world/world.lua:210: in function 'update'
		gamestates/inGame.lua:177: in function <gamestates/inGame.lua:155>
		stackManager.lua:59: in function 'update'
		[string "boot.lua"]:612: in function <[string "boot.lua"]:594>
		[C]: in function 'xpcall'

There is nothing in this stack trace that mentions structure.lua. We
just know that someone inserted an invalid event into
world.events.create, and world.lua failed when it tried to process that
event. With the new system, this is the stack trace we get:

	Error: world/worldObjects.lua:7: attempt to index local 'location' (a number value)
	stack traceback:
		[string "boot.lua"]:777: in function '__index'
		world/worldObjects.lua:7: in function '__create'
		class.lua:5: in function 'parent'
		class.lua:4: in function 'Structure'
		world/structure.lua:347: in function 'fn'
		world/world.lua:206: in function 'update'
		gamestates/inGame.lua:177: in function <gamestates/inGame.lua:155>
		stackManager.lua:59: in function 'update'
		[string "boot.lua"]:612: in function <[string "boot.lua"]:594>
		[C]: in function 'xpcall'

Because it's the caller's responsibility to create the object, the
caller will fail. Now structure.lua is in the stack trace. "Attempt to
index local 'location' (a number value)" makes sense; we can see that
structure.lua is passing a number instead of a table to Structure() on
line 347:

	self.createObject(function(worldInfo)
		return (Structure(worldInfo, 0, {parts = structure}))
	end)