### PR TITLE
Add debug info about code that generates events

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -129,11 +129,7 @@ function Player:buttonpressed(source, button, debugmode)
 			end
 
 			if part and location then
-				-- TODO: Move this pattern to a function and write a unit test
-				-- for it.
-				location = LocationTable(unpack(location))
-				table.insert(self.world.info.events.create,
-							 {"structure", location, part})
+				self.world.info.create("structure", LocationTable(unpack(location)), part)
 			end
 			self.menu = nil
 		end

--- a/src/world/structure.lua
+++ b/src/world/structure.lua
@@ -11,7 +11,7 @@ local Structure = class(require("world/worldObjects"))
 function Structure:__create(worldInfo, location, data, appendix)
 	self.worldInfo = worldInfo
 	self.physics = worldInfo.physics
-	self.events = worldInfo.events
+	self.createObject = worldInfo.create
 
 	local shipTable
 	if appendix then
@@ -343,8 +343,7 @@ function Structure:disconnectPart(location, isDestroyed)
 
 		end
 
-		local newStructure = {"structure", location, {parts = structure}}
-		table.insert(self.events.create, newStructure)
+		self.createObject("structure", location, {parts = structure})
 	end
 end
 
@@ -379,7 +378,7 @@ function Structure:command(dt)
 	local function create(object, location)
 		location = StructureMath.sumVectors(location, object[2])
 		object[2] = self:getWorldLocation(location)
-		table.insert(self.events.create, object)
+		self.createObject(unpack(object))
 	end
 
 


### PR DESCRIPTION
This debug info says what line of code submitted the event, so if the
event has bad data you can find who submitted that bad data and why.

When an event fails, world.lua will continue processing the rest of the
events, but it will print an error message like this:

    ERROR: Creating an object in the world failed. Event generated
    at @world/structure.lua:346 in function 'disconnectPart'.
    world/worldObjects.lua:7: attempt to index local 'location' (a
    number value)