### PR TITLE
Fix crash in menu

### DIFF
--- a/src/menu.lua
+++ b/src/menu.lua
@@ -148,11 +148,15 @@ end
 
 function Menu:keypressed(key)
 	if key == "up" then
-		if self.selectedButton > 1 then
+		if self.selectedButton == nil then
+			self.selectedButton = #self.buttons
+		elseif self.selectedButton > 1 then
 			self.selectedButton = self.selectedButton - 1
 		end
 	elseif key == "down" then
-		if self.selectedButton < #self.buttons then
+		if self.selectedButton == nil then
+			self.selectedButton = 1
+		elseif self.selectedButton < #self.buttons then
 			self.selectedButton = self.selectedButton + 1
 		end
 	elseif key == "return" then


### PR DESCRIPTION
If you used the arrow keys to make a menu selection before hovering over
any buttons with the mouse, you would get this error:

	Error: menu.lua:155: attempt to compare nil with number

Now this comparison is protected against nil values.