### PR TITLE
Allow free rotation of the camera

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -7,6 +7,7 @@ function Camera.create()
 
 	self.x = 0
 	self.y = 0
+	self.angle = 0
 	self.zoomInt = 8
 	self:adjustZoom(0)
 	self.scissorX = 0
@@ -21,7 +22,7 @@ function Camera.create()
 end
 
 function Camera:getPosition()
-	return self.x, self.y
+	return self.x, self.y, self.angle
 end
 
 function Camera:setX(newX)
@@ -30,6 +31,10 @@ end
 
 function Camera:setY(newY)
 	self.y = newY
+end
+
+function Camera:setAngle(newAngle)
+	self.angle = newAngle
 end
 
 function Camera:getWorldCoords(cursorX, cursorY)
@@ -182,6 +187,7 @@ function Camera:enable(inWorld)
 	love.graphics.translate(self.scissorX, self.scissorY)
 	if inWorld then
 		love.graphics.translate(self.scissorWidth/2, self.scissorHeight/2)
+		love.graphics.rotate(self.angle)
 		love.graphics.scale(self.zoom, -self.zoom)
 		love.graphics.translate(- self.x, - self.y)
 		--x =  self.zoom * (worldX - self.x) + self.scissorX + self.scissorWidth/2

--- a/src/player.lua
+++ b/src/player.lua
@@ -37,6 +37,7 @@ function Player.create(world, controls, structure, camera)
 	self.selectionKeyDown = false
 	self.isBuilding = false
 	self.isRemoving = false
+	self.isCameraAngleFixed = true
 	self.partX = nil
 	self.partY = nil
 	self.cursorX = 0
@@ -54,6 +55,7 @@ function Player:handleInput()
 	if self.ship then
 		self.camera:setX(self.ship.body:getX())
 		self.camera:setY(self.ship.body:getY())
+		self.camera:setAngle(self.isCameraAngleFixed and 0 or self.ship.body:getAngle())
 	end
 
 	-----------------------
@@ -80,6 +82,7 @@ end
 
 function Player:buttonpressed(source, button, debugmode)
 	if button == "h" then self.showHealth = not self.showHealth end
+	if button == "f5" then self.isCameraAngleFixed = not self.isCameraAngleFixed end
 
 	local menuButton = Controls.test("menu", self.controls, source, button)
 	local order = Controls.test("pressed", self.controls, source, button)
@@ -184,6 +187,7 @@ function Player:draw(debugmode)
 	if self.ship then
 		self.camera:setX(self.ship.body:getX())
 		self.camera:setY(self.ship.body:getY())
+		self.camera:setAngle(self.isCameraAngleFixed and 0 or self.ship.body:getAngle())
 	end
 
 	self:drawWorldObjects(debugmode)
@@ -332,9 +336,9 @@ function Player:drawHUD()
 		love.graphics.setFont(previousFont)
 	end
 
-	local x, y = self.camera:getPosition()
+	local x, y, angle = self.camera:getPosition()
 	local _, _, width, height = self.camera:getScissor()
-	local compassAngle = math.atan2(x - point[1], y - point[2]) + math.pi/2
+	local compassAngle = math.atan2(x - point[1], y - point[2]) + math.pi/2 + (self.isCameraAngleFixed and 0 or angle)
 
 	drawCompass(width, height, compassAngle)
 


### PR DESCRIPTION
Press F5 to toggle the rotation mode. By default up will always be
north. Pressing F5 will switch up to be the direction your ship is
pointing.

Closes https://github.com/synthein/synthein/issues/160