### PR TITLE
Remove duplicate camera position syncing code

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -51,13 +51,6 @@ function Player.create(world, controls, structure, camera)
 end
 
 function Player:handleInput()
-
-	if self.ship then
-		self.camera:setX(self.ship.body:getX())
-		self.camera:setY(self.ship.body:getY())
-		self.camera:setAngle(self.isCameraAngleFixed and 0 or self.ship.body:getAngle())
-	end
-
 	-----------------------
 	----- Set Cursor  -----
 	-----------------------


### PR DESCRIPTION
This code was copied to Player.draw() to fix a bug in 2017. This is
where it belongs. We don't need 2 copies.