### PR TITLE
Add logging

### DIFF
--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -1,9 +1,10 @@
 local Debug = require("debugmode")
-local console = require("console")
 local Gamesave = require("gamesave")
 local LocationTable = require("locationTable")
+local Log = require("log")
 local Menu = require("menu")
 local SceneParser = require("sceneParser")
+local console = require("console")
 local utf8 = require("utf8")
 local vector = require("vector")
 
@@ -27,11 +28,12 @@ end
 local typingSaveName = false
 local saveName = ""
 
-local world, players, screen, debugmode
+local world, players, screen, debugmode, log
 function InGame.load(...)
 	world, players, screen = ...
 
 	debugmode = Debug.create(world, players)
+	log = Log(debugmode)
 	console.init({
 		players = players,
 		world = world,
@@ -190,8 +192,17 @@ function InGame.update(dt)
 					local veloVar = 1 - 50/(1 + vector.magnitude(
 								player.ship.body:getLinearVelocity()))
 					if veloVar < 0 then veloVar = 0 end
+
 					local rand = love.math.random()
-					if rand < timeVar * disVar * veloVar or
+					local product = timeVar * disVar * veloVar
+
+					log:debug("Spawn roll: %s < %s ? %s",
+						rand,
+						product,
+						{timeVar=timeVar, disVar=disVar, veloVar=veloVar}
+					)
+
+					if rand < product or
 							(debugmode.on and debugmode:getSpawn()) then
 						eventTime = 0
 						local scene = math.ceil(love.math.random() * 10)
@@ -222,6 +233,7 @@ function InGame.update(dt)
 						for _, ship in ipairs(ships) do
 							world:addObject(ship)
 						end
+						log:info("Spawned scene " .. scene)
 					end
 				end
 			end

--- a/src/log.lua
+++ b/src/log.lua
@@ -1,0 +1,37 @@
+local Log = class()
+
+function Log:__create(debugmode)
+  self.debugmode = debugmode
+end
+
+local function texpand(t)
+  local str
+  for k, v in pairs(t) do
+    if str == nil then
+      str = "{"
+    else
+      str = str .. ", "
+    end
+
+    str = str .. string.format("%s = %s", k, v)
+  end
+  return str .. "}"
+end
+
+local function out(message, ...)
+  local processed = {}
+  for i, v in pairs({...}) do
+    processed[i] = type(v) == "table" and texpand(v) or v
+  end
+  io.stderr:write(os.date() .. " " .. string.format(message, unpack(processed)) .. "\n")
+end
+
+function Log:info(message, ...)
+  out("INFO " .. message, ...)
+end
+
+function Log:debug(message, ...)
+  if self.debugmode.on then out("DEBUG " .. message, ...) end
+end
+
+return Log


### PR DESCRIPTION
There is debug logging and info logging. Debug logs only show up in
debug mode. More levels could be added later. Here's what they look
like:

	Thu May 19 23:40:55 2022 DEBUG Spawn roll: 0.29148211509861 < 0.15024492302707 ? {veloVar = 0.46091839316567, timeVar = 0.47925513078335, disVar = 0.68015672320563}
	Thu May 19 23:40:56 2022 DEBUG Spawn roll: 0.27941323186205 < 0.16417074829717 ? {veloVar = 0.49128234171581, timeVar = 0.4846199032662, disVar = 0.68954621145571}
	Thu May 19 23:40:57 2022 DEBUG Spawn roll: 0.050190738433318 < 0.17665372602824 ? {veloVar = 0.51597348075896, timeVar = 0.48987954703552, disVar = 0.6988856342497}
	Thu May 19 23:40:57 2022 INFO Spawned scene 5

As a bonus, the logging functions automatically expand tables. So a
log like this:

	t = {player="jordan", team=1}
	log:info("Player table: %s", t)

Will look like this:

	Thu May 19 23:59:59 2022 INFO Player table: {player = jordan, team = 1}