### PR TITLE
Fix debug spawning

### DIFF
--- a/src/debugmode.lua
+++ b/src/debugmode.lua
@@ -12,7 +12,7 @@ function Debug.create(world, players)
 end
 
 function Debug:getSpawn()
-	local value = Debug.spawn
+	local value = self.spawn
 	self.spawn = false
 	return value
 end


### PR DESCRIPTION
Pressing "n" in debug mode should force spawning in a random encounter.
Previously it did nothing. Debug.spawn is always false.