### PR TITLE
Mock out unavailable Love APIs during tests

### DIFF
--- a/src/conf.lua
+++ b/src/conf.lua
@@ -36,7 +36,11 @@ function love.conf(t)
 
 	for _, flag in ipairs(arg) do
 		if flag == "--test" then
+			local stub = require("tests/stub")
 			t.window, t.modules.window, t.modules.graphics, t.modules.audio = false, false, false, false
+			love.window = stub()
+			love.graphics = stub()
+			love.audio = stub()
 		end
 	end
 end

--- a/src/tests/stub.lua
+++ b/src/tests/stub.lua
@@ -1,0 +1,9 @@
+return function()
+  local stub = {}
+  return setmetatable(stub, {
+    __index = function() return stub end,
+    __call = function() return stub, stub end,
+    __sub = function() return 1 end,
+    __div = function() return 1 end,
+  })
+end


### PR DESCRIPTION
Yay, tests are working again!

```
$ make test
love src --test

-- Starting suite "tests.test_gameState", 4 test(s)
  ....
-- Starting suite "tests.test_inGame", 1 test(s)
  .
-- Starting suite "tests.test_physicsReferences", 2 test(s)
  ..
-- Starting suite "tests.test_player", 1 test(s)
  .
---- Testing finished in 0.34 ms, with 6 assertion(s) ----
  8 passed, 0 failed, 0 error(s), 0 skipped.
```