### PR TITLE
Update selected button in inGame mode

### DIFF
--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -125,6 +125,10 @@ function InGame.mousereleased(x, y, button)
 	end
 end
 
+function InGame.mousemoved(x, y)
+	menu:mousemoved(x, y)
+end
+
 function InGame.joystickpressed(joystick, button)
 	for _, player in ipairs(players) do
 		player:buttonpressed(joystick, button)


### PR DESCRIPTION
Without this, the button under the mouse cursor doesn't highlight.