### PR TITLE
Make mouse work in some menus

### DIFF
--- a/src/gamestates/formationEditor.lua
+++ b/src/gamestates/formationEditor.lua
@@ -143,7 +143,7 @@ end
 function FormationEditor.mousepressed(x, y, mouseButton)
 	if menuOpen == "State" then
 		if mouseButton == 1 then
-			local button = FormationEditor.menu:pressed(x, y)
+			local button = FormationEditor.menu:getButtonAt(x, y)
 
 			if button == "Main Menu" then
 				menuOpen = false

--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -102,7 +102,7 @@ end
 function InGame.mousepressed(x, y, button)
 	if menuOpen == "Pause" then
 		if button == 1 then
-			pauseMenuAction(menu:pressed(x, y))
+			pauseMenuAction(menu:getButtonAt(x, y))
 		end
 	else
 		for _, player in ipairs(players) do

--- a/src/gamestates/newGameMenu.lua
+++ b/src/gamestates/newGameMenu.lua
@@ -26,9 +26,8 @@ function NewGameMenu.keypressed(key)
 end
 
 function NewGameMenu.mousepressed(x, y, mouseButton)
-	local button = NewGameMenu.menu:pressed(x, y)
 	if mouseButton == 1 then
-		NewGameMenu.testButton(button)
+		NewGameMenu.testButton(NewGameMenu.menu:getButtonAt(x, y))
 	end
 end
 


### PR DESCRIPTION
Several menus were recently switched to use button indexes instead of button names. Some of the menus didn't update the mouse controls to match.