### PR TITLE
Allow setting timers after they're created

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -23,6 +23,7 @@ impl UserData for Timer {
     fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
         fields.add_field_method_get("limit", |_, this| Ok(this.limit));
         fields.add_field_method_get("time", |_, this| Ok(this.time));
+        fields.add_field_method_set("time", |_, this, val: f64| Ok(this.time = val));
     }
 
     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {


### PR DESCRIPTION
This is a feature that got missed when converting timer from Lua to Rust. Setting the time remaining on an existing timer isn't a commonly used feature, but it is necessary for loading timers from save data.