### PR TITLE
Move make run to a separate script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,6 @@ rust:
 	cp target/release/libsyntheinrust.so src/syntheinrust.so
 
 # Maintenance commands
-run: rust
-	love src
-
 check:
 	find src -name '*.lua' -not -path 'src/vendor/*' | xargs wc -l | sort -rg
 	find src -name '*.lua' -exec luac -p {} + && echo "No problems found"

--- a/run
+++ b/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+make
+love src "$@"


### PR DESCRIPTION
It's difficult to pass additional arguments to make. A script is better for this.