### PR TITLE
Simplify AppImage build script

### DIFF
--- a/package/synthein.appimage.sh
+++ b/package/synthein.appimage.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec love share/synthein/synthein.love "$@"

--- a/package/synthein.desktop
+++ b/package/synthein.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Synthein
 Comment=A space ship building and combat game
-Exec=synthein
+Exec=love share/synthein/synthein.love
 Icon=synthein
 Terminal=false
 Type=Application

--- a/package/synthein.sh
+++ b/package/synthein.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec love /usr/share/synthein/synthein.love "$@"


### PR DESCRIPTION
Now that LOVE ships an official AppImage, it's a bit easier to build an AppImage for Synthein. We just unpack LOVE's AppImage, drop in our .love file, update the icon and .desktop file, and we're done. This is more similar to how the Mac and Windows packages work: just download the official LOVE build and add our stuff to it.

Additionally, the AppImage now ships with our Rust code, so it is able to load the Rust-based modules.