### PR TITLE
Fix tests

### DIFF
--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -77,7 +77,7 @@ function InGame.load(scene, playerHostility, ifSave)
 
 	world = World(playerHostility)
 
-	local screen = Screen()
+	screen = Screen()
 
 	local playerShips, maxTeam = SceneParser.loadScene(sceneLines, world, {0,0,0,0,0,0})
 	-- TODO: Instead of creating players here, we should create one

--- a/src/tests/stub.lua
+++ b/src/tests/stub.lua
@@ -4,6 +4,7 @@ return function()
     __index = function() return stub end,
     __call = function() return stub, stub end,
     __sub = function() return 1 end,
+    __mul = function() return 1 end,
     __div = function() return 1 end,
   })
 end

--- a/src/tests/test_inGame.lua
+++ b/src/tests/test_inGame.lua
@@ -5,7 +5,7 @@ local t = {}
 
 function t.test_screen_resize_should_not_crash()
 	local screen = Screen()
-	InGame.load({}, {}, screen)
+	InGame.load("test-general1", {}, false)
 	InGame.resize(100, 100)
 end
 

--- a/src/tests/test_player.lua
+++ b/src/tests/test_player.lua
@@ -6,26 +6,4 @@ local PhysicsReferences = require("world/physicsReferences")
 
 local t = {}
 
-function t.test_player_should_draw_world_objects()
-	local drawCalls = 0
-	local block = {draw = function() drawCalls = drawCalls + 1 end}
-	local blockFixture = {
-		getUserData = function() return block end,
-		getFilterData = function() return PhysicsReferences.categories.general end,
-	}
-
-	local player = {
-		camera = Camera.create(),
-		world = {
-			physics = {
-				queryBoundingBox = function(_, _, _, _, _, fn) fn(blockFixture) end,
-			}
-		}
-	}
-
-	Player.drawWorldObjects(player, false)
-
-	test.assert_equal(1, drawCalls)
-end
-
 return t


### PR DESCRIPTION
- The player test doesn't make sense anymore. There is no drawWorldObjects function anymore.
- InGame.load() changed, so the inGame test needed to update how it called that function.
- The inGame test caught a real regression! If you resize the window by going to full screen during inGame, the game would crash. Now it's fixed.