### PR TITLE
Add an integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,5 +37,6 @@ luacheck:
 
 test:
 	love src --test
+	lua test/init.lua
 
 .PHONY: appimage check clean dep love luacheck macos rust test windows

--- a/src/conf.lua
+++ b/src/conf.lua
@@ -35,7 +35,7 @@ function love.conf(t)
 	t.modules.thread = true              -- Enable the thread module (boolean)
 
 	for _, flag in ipairs(arg) do
-		if flag == "--test" then
+		if flag == "--test" or flag == "--integration" then
 			local stub = require("tests/stub")
 			t.window, t.modules.window, t.modules.graphics, t.modules.audio = false, false, false, false
 			love.window = stub()

--- a/src/tests/stub.lua
+++ b/src/tests/stub.lua
@@ -3,6 +3,7 @@ return function()
   return setmetatable(stub, {
     __index = function() return stub end,
     __call = function() return stub, stub end,
+    __add = function() return 1 end,
     __sub = function() return 1 end,
     __mul = function() return 1 end,
     __div = function() return 1 end,

--- a/test/init.lua
+++ b/test/init.lua
@@ -1,0 +1,1 @@
+os.execute("love src --integration --scene test-general1")


### PR DESCRIPTION
This is the first of many integration tests, where we test features of the game while it is running via it's interface(s). The first test starts the game in a scene. It should check to see if it fails and stop the game once the tests are complete, but that's not yet implemented.