### PR TITLE
Add the first real integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ luacheck:
 	find src -name '*.lua' -not -path 'src/vendor/*' -exec luacheck --no-unused-args {} +
 
 test:
-	love src --test
-	lua test/init.lua
+	love src --unit-tests
+	test/init.sh
 
 .PHONY: appimage check clean dep love luacheck macos rust test windows

--- a/src/conf.lua
+++ b/src/conf.lua
@@ -35,7 +35,7 @@ function love.conf(t)
 	t.modules.thread = true              -- Enable the thread module (boolean)
 
 	for _, flag in ipairs(arg) do
-		if flag == "--test" or flag == "--integration" then
+		if flag == "--unit-tests" or flag == "--headless" then
 			local stub = require("tests/stub")
 			t.window, t.modules.window, t.modules.graphics, t.modules.audio = false, false, false, false
 			love.window = stub()

--- a/src/console.lua
+++ b/src/console.lua
@@ -27,7 +27,10 @@ function console.repl()
 			-- of the function. We don't currently use the first
 			-- return value. We print errors or results for the
 			-- user to see.
-			print(select(2, pcall(code)))
+			local results = {select(2, pcall(code))}
+			if #results > 0 then
+				print(unpack(results))
+			end
 		end
 	end
 end

--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -116,6 +116,7 @@ function InGame.load(scene, playerHostility, ifSave)
 	console.init({
 		players = players,
 		world = world,
+		quit = love.event.quit
 	})
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -27,7 +27,7 @@ function love.load()
 
 	local i = 1
 	while arg[i] do
-		if arg[i] == "--test" then
+		if arg[i] == "--unit-tests" then
 			require("tests")
 			love.event.quit()
 		elseif arg[i]:match("^--scene") then

--- a/src/res/scenes/test-general1.txt
+++ b/src/res/scenes/test-general1.txt
@@ -22,11 +22,11 @@ g*
 }
 structure(8,0,0)[0]
 {
-a*
+r*
 }
 structure(2,2,0)[0]
 {
-r*
+a*
 }
 structure(4,2,0)[0]
 {

--- a/test/init.lua
+++ b/test/init.lua
@@ -1,1 +1,0 @@
-os.execute("love src --integration --scene test-general1")

--- a/test/init.sh
+++ b/test/init.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+find "$(dirname "$0")" -name 'test_*.sh' -exec sh -eu {} \;

--- a/test/test_heal.sh
+++ b/test/test_heal.sh
@@ -1,0 +1,34 @@
+input=$(mktemp -u)
+mkfifo "$input"
+output=$(mktemp)
+result=0
+
+love src --headless --scene test-general1 < "$input" > "$output" 2>/dev/null &
+exec 3>"$input"
+
+cat >> "$input" <<EOF
+players[1].ship.corePart.modules.hull.health = 1
+EOF
+
+sleep 1
+
+cat >> "$input" <<EOF
+return players[1].ship.corePart.modules.hull.health
+quit()
+EOF
+
+exec 3>&-
+wait
+
+actual=$(cat "$output")
+if [ $actual -gt 1 ]; then
+	printf .
+else
+	printf "FAILED: expected %s > 1\n" "$actual"
+	result=1
+fi
+
+rm "$input"
+rm "$output"
+
+exit $result


### PR DESCRIPTION
This adds a test of the heal module that starts the game and watches an injured player to see if it heals after some time. Currently this test fails because the heal module appears to be broken.

In test-general1, I moved the repair part away from the player so that it wouldn't repair the player. I only want to see the heal module working.