### PR TITLE
Fix broken heal module test

### DIFF
--- a/test/test_heal.sh
+++ b/test/test_heal.sh
@@ -8,6 +8,7 @@ exec 3>"$input"
 
 cat >> "$input" <<EOF
 players[1].ship.corePart.modules.hull.health = 1
+players[1].ship.corePart.modules.heal.timer.time = 0.1
 EOF
 
 sleep 1


### PR DESCRIPTION
I previously thought that the heal module wasn't working, but it actually works fine. It just heals more slowly than I was willing to wait in my tests.

Since the heal module activates once every 10 seconds, and I didn't want to have a test that took 10 seconds to run, I made the test adjust the heal module's timer to be just about to fire when the test starts.