### PR TITLE
Suppress stderr from tests unless the test fails

### DIFF
--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -12,7 +12,7 @@ extra_args=
 ! [ "${SYNTHEIN_ENABLE_TEST_GRAPHICS:-0}" = 1 ] && extra_args="$extra_args --headless"
 
 # Run test
-message=$(sh -eu "$1" "$input" "$output" "$extra_args")
+message=$(sh -eu "$1" "$input" "$output" "$extra_args" 2>&1)
 result=$?
 if [ "$result" -eq 0 ]; then
 	printf .


### PR DESCRIPTION
This prevents a wall of "Controls binding file does not exist" warnings during the "test every scene" test.