### PR TITLE
Print the problematic scene's name in test_all_scenes

### DIFF
--- a/test/test_all_scenes.sh
+++ b/test/test_all_scenes.sh
@@ -3,11 +3,8 @@
 extra_args="$3"
 
 find src/res/scenes -name '*.txt' | sed -E 's|.*/([[:alnum:]_-]+).txt|\1|' | while IFS= read -r scene; do
-	love src $extra_args --scene "$scene" <<EOF
-quit()
-EOF
-	
-	if [ $? -gt 0 ]; then
+	if ! echo "quit()" | love src $extra_args --scene "$scene"
+	then
 		printf "FAILED: scene %s crashed\n" "$scene"
 		return 1
 	fi


### PR DESCRIPTION
This test was supposed to print the name of the scene that crashed, but it had a bug that prevented it from doing that. run_test.sh runs all tests in `set -e` mode, which means "if any command fails, abort the script". This means that once LOVE exited with an error, the test would abort without ever getting to the code where we print the scene name.

Now we catch and handle the error inside the test.