### PR TITLE
Fix a couple log issues

### DIFF
--- a/src/log.lua
+++ b/src/log.lua
@@ -1,17 +1,17 @@
 local Log = class()
 
 function Log:__create(debugmode)
-  self.debugmode = debugmode
+  self.debugmode = debugmode or {}
 end
 
 local function texpand(t)
-  local str
+  local str = "{"
+  local num_items = 0
   for k, v in pairs(t) do
-    if str == nil then
-      str = "{"
-    else
+    if num_items > 0 then
       str = str .. ", "
     end
+    num_items = num_items + 1
 
     str = str .. string.format("%s = %s", k, v)
   end

--- a/src/world/world.lua
+++ b/src/world/world.lua
@@ -1,4 +1,4 @@
-local Log = require("log")
+local log = require("log")
 local PhysicsReferences = require("world/physicsReferences")
 
 local World = class()
@@ -10,8 +10,6 @@ local objectTypes = {
 	particles = require("world/particles"),
 }
 World.objectTypes = objectTypes
-
-local log = Log({})
 
 -- The world object contains all of the state information about the game world
 -- and is responsible for updating and drawing everything in the game world.


### PR DESCRIPTION
1. Prevent crashes when trying to log an empty table.
2. Don't require passing a table to Log(). Default to an empty table instead of requiring users to do that.