### PR TITLE
Delete non-existent files in a zip file when updating it

### DIFF
--- a/scripts/package-love.sh
+++ b/scripts/package-love.sh
@@ -6,7 +6,10 @@ build_file="${PWD}/build/synthein-${SYNTHEIN_VERSION}.love"
 mkdir -p "$(dirname "$build_file")"
 
 cd src
-zip -9 -r "${build_file}" res $(find . -name '*.lua') $(find . -name '*.so' -not -path '*/target/*')
+zip -9 --filesync -r "${build_file}" \
+	res \
+	$(find . -name '*.lua') \
+	$(find . -name '*.so' -not -path '*/target/*')
 
 cd ../build
 echo "return \"${SYNTHEIN_VERSION}\"" > version.lua


### PR DESCRIPTION
When we build a .love file, we update it if it already exists. There was previously a bug where we would only add files. We wouldn't delete files that no longer exist. This made it difficult to use git-bisect, for example. If we tried to go back and test a version where we used only Lua code, but we had some .so modules in the .love file, we might not be running the correct code. Now we can be sure that the code in the .love file is always up to date.