### PR TITLE
Fix location data in saves

### DIFF
--- a/src/sceneParser.lua
+++ b/src/sceneParser.lua
@@ -145,7 +145,7 @@ function SceneParser.saveScene(world)
 		local data, appendix = object:getSaveData(references)
 		local string = ""
 			.. references[object] .. " = " .. object:type()
-			.. "(" .. tostring(object:getLocation()) .. ")"
+			.. "(" .. Parse.packLocation(object:getLocation()) .. ")"
 			.. Parse.packData(data) .. "\n"
 			.. (appendix and "{\n" .. appendix .. "\n}\n" or "")
 


### PR DESCRIPTION
When we switched from the LocationTable object to a plain table, we lost the __tostring() implementation that LocationTable had. SceneParser.saveScene() still used tostring(), so location tables in save files were getting serialized as (table 0x1234) instead of the expected (1, 1, 1, 0, 0, 0) or similar.