### PR TITLE
Separate lua_module code from Rust modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,7 @@ use mlua::{Lua, Result};
 mod timer;
 mod world;
 
-use world::shipparts::modules::gun;
-use world::shipparts::modules::heal;
-use world::shipparts::modules::missile_launcher;
+use world::shipparts::modules::lua_interfaces::*;
 
 #[mlua::lua_module]
 fn syntheinrust(lua: &Lua) -> Result<LuaTable> {

--- a/src/world/shipparts/modules/gun.rs
+++ b/src/world/shipparts/modules/gun.rs
@@ -1,15 +1,14 @@
 use crate::timer::Timer;
 use crate::world::types::{Location, Module, ModuleInputs, WorldEvent};
-use mlua::prelude::{LuaTable, LuaValue};
-use mlua::{Lua, Result, ToLua, UserData, UserDataMethods};
+use mlua::{Lua, UserData, UserDataMethods};
 
-fn process(orders: Vec<String>) -> bool {
+pub fn process(orders: Vec<String>) -> bool {
     orders.iter().any(|order| order == "shoot")
 }
 
-struct Gun {
-    charged: bool,
-    recharge_timer: Timer,
+pub struct Gun {
+    pub charged: bool,
+    pub recharge_timer: Timer,
 }
 
 impl Module for Gun {
@@ -50,30 +49,4 @@ impl UserData for Gun {
             },
         );
     }
-}
-
-pub fn lua_module(lua: &Lua) -> Result<LuaTable> {
-    let exports = lua.create_table()?;
-    exports.set(
-        "process",
-        lua.create_function(|_, orders: Vec<String>| Ok(process(orders)))?,
-    )?;
-
-    let metatable = lua.create_table()?;
-    metatable.set(
-        "__call",
-        lua.create_function(|lua, _: LuaValue| {
-            Gun {
-                charged: true,
-                recharge_timer: Timer {
-                    limit: 0.5,
-                    time: 0.5,
-                },
-            }
-            .to_lua(lua)
-        })?,
-    )?;
-    exports.set_metatable(Some(metatable));
-
-    Ok(exports)
 }

--- a/src/world/shipparts/modules/heal.rs
+++ b/src/world/shipparts/modules/heal.rs
@@ -1,11 +1,11 @@
 use crate::timer::Timer;
 use crate::world::types::{Location, Module, ModuleInputs, WorldEvent};
 use mlua::prelude::{LuaFunction, LuaTable};
-use mlua::{Lua, RegistryKey, Result, ToLua, UserData, UserDataFields, UserDataMethods};
+use mlua::{Lua, RegistryKey, UserData, UserDataFields, UserDataMethods};
 
-struct Heal {
-    timer: Timer,
-    hull: RegistryKey,
+pub struct Heal {
+    pub timer: Timer,
+    pub hull: RegistryKey,
 }
 
 impl Module for Heal {
@@ -35,26 +35,4 @@ impl UserData for Heal {
             Ok(Heal::update(this, lua, inputs, location))
         });
     }
-}
-
-pub fn lua_module(lua: &Lua) -> Result<LuaTable> {
-    let exports = lua.create_table()?;
-
-    let metatable = lua.create_table()?;
-    metatable.set(
-        "__call",
-        lua.create_function(|lua, (_, hull): (LuaTable, LuaTable)| {
-            Heal {
-                timer: Timer {
-                    limit: 10.0,
-                    time: 10.0,
-                },
-                hull: lua.create_registry_value(hull)?,
-            }
-            .to_lua(lua)
-        })?,
-    )?;
-    exports.set_metatable(Some(metatable));
-
-    Ok(exports)
 }

--- a/src/world/shipparts/modules/lua_interfaces/gun.rs
+++ b/src/world/shipparts/modules/lua_interfaces/gun.rs
@@ -1,0 +1,30 @@
+use crate::timer::Timer;
+use crate::world::shipparts::modules::gun::{process, Gun};
+use mlua::prelude::{LuaTable, LuaValue};
+use mlua::{Lua, Result, ToLua};
+
+pub fn lua_module(lua: &Lua) -> Result<LuaTable> {
+    let exports = lua.create_table()?;
+    exports.set(
+        "process",
+        lua.create_function(|_, orders: Vec<String>| Ok(process(orders)))?,
+    )?;
+
+    let metatable = lua.create_table()?;
+    metatable.set(
+        "__call",
+        lua.create_function(|lua, _: LuaValue| {
+            Gun {
+                charged: true,
+                recharge_timer: Timer {
+                    limit: 0.5,
+                    time: 0.5,
+                },
+            }
+            .to_lua(lua)
+        })?,
+    )?;
+    exports.set_metatable(Some(metatable));
+
+    Ok(exports)
+}

--- a/src/world/shipparts/modules/lua_interfaces/heal.rs
+++ b/src/world/shipparts/modules/lua_interfaces/heal.rs
@@ -1,0 +1,26 @@
+use crate::timer::Timer;
+use crate::world::shipparts::modules::heal::Heal;
+use mlua::prelude::LuaTable;
+use mlua::{Lua, Result, ToLua};
+
+pub fn lua_module(lua: &Lua) -> Result<LuaTable> {
+    let exports = lua.create_table()?;
+
+    let metatable = lua.create_table()?;
+    metatable.set(
+        "__call",
+        lua.create_function(|lua, (_, hull): (LuaTable, LuaTable)| {
+            Heal {
+                timer: Timer {
+                    limit: 10.0,
+                    time: 10.0,
+                },
+                hull: lua.create_registry_value(hull)?,
+            }
+            .to_lua(lua)
+        })?,
+    )?;
+    exports.set_metatable(Some(metatable));
+
+    Ok(exports)
+}

--- a/src/world/shipparts/modules/lua_interfaces/missile_launcher.rs
+++ b/src/world/shipparts/modules/lua_interfaces/missile_launcher.rs
@@ -1,0 +1,30 @@
+use crate::timer::Timer;
+use crate::world::shipparts::modules::missile_launcher::{process, MissileLauncher};
+use mlua::prelude::{LuaTable, LuaValue};
+use mlua::{Lua, Result, ToLua};
+
+pub fn lua_module(lua: &Lua) -> Result<LuaTable> {
+    let exports = lua.create_table()?;
+    exports.set(
+        "process",
+        lua.create_function(|_, orders: Vec<String>| Ok(process(orders)))?,
+    )?;
+
+    let metatable = lua.create_table()?;
+    metatable.set(
+        "__call",
+        lua.create_function(|lua, _: LuaValue| {
+            MissileLauncher {
+                charged: true,
+                recharge_timer: Timer {
+                    limit: 1.0,
+                    time: 1.0,
+                },
+            }
+            .to_lua(lua)
+        })?,
+    )?;
+    exports.set_metatable(Some(metatable));
+
+    Ok(exports)
+}

--- a/src/world/shipparts/modules/lua_interfaces/mod.rs
+++ b/src/world/shipparts/modules/lua_interfaces/mod.rs
@@ -1,5 +1,3 @@
 pub mod gun;
 pub mod heal;
 pub mod missile_launcher;
-
-pub mod lua_interfaces;

--- a/src/world/shipparts/modules/missile_launcher.rs
+++ b/src/world/shipparts/modules/missile_launcher.rs
@@ -1,15 +1,15 @@
 use crate::timer::Timer;
 use crate::world::types::{Location, Module, ModuleInputs, WorldEvent};
-use mlua::prelude::{LuaTable, LuaValue};
-use mlua::{Lua, Nil, Result, ToLua, UserData, UserDataMethods};
+use mlua::prelude::LuaValue;
+use mlua::{Lua, Nil, UserData, UserDataMethods};
 
-fn process(orders: Vec<String>) -> bool {
+pub fn process(orders: Vec<String>) -> bool {
     orders.iter().any(|order| order == "shoot")
 }
 
-struct MissileLauncher {
-    charged: bool,
-    recharge_timer: Timer,
+pub struct MissileLauncher {
+    pub charged: bool,
+    pub recharge_timer: Timer,
 }
 
 impl Module for MissileLauncher {
@@ -50,30 +50,4 @@ impl UserData for MissileLauncher {
             },
         );
     }
-}
-
-pub fn lua_module(lua: &Lua) -> Result<LuaTable> {
-    let exports = lua.create_table()?;
-    exports.set(
-        "process",
-        lua.create_function(|_, orders: Vec<String>| Ok(process(orders)))?,
-    )?;
-
-    let metatable = lua.create_table()?;
-    metatable.set(
-        "__call",
-        lua.create_function(|lua, _: LuaValue| {
-            MissileLauncher {
-                charged: true,
-                recharge_timer: Timer {
-                    limit: 1.0,
-                    time: 1.0,
-                },
-            }
-            .to_lua(lua)
-        })?,
-    )?;
-    exports.set_metatable(Some(metatable));
-
-    Ok(exports)
 }


### PR DESCRIPTION
This will hopefully make it easier to remove the Lua glue code once we no longer need it.