### PR TITLE
Make player 2's cursor visible

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -1,7 +1,8 @@
+local Hud = require("hud")
 local PhysicsReferences = require("world/physicsReferences")
 local Settings = require("settings")
+local lume = require("vendor/lume")
 local vector = require("vector")
-local Hud = require("hud")
 
 local Camera = {}
 Camera.__index = Camera
@@ -186,22 +187,10 @@ function Camera:setScissor(x, y, width, height)
 end
 
 function Camera:limitCursor(cursorX, cursorY)
-	local scissor = self.scissor
-	local x = scissor.x
-	local y = scissor.y
-	local width = scissor.width
-	local height = scissor.height
-	if cursorX < x then
-		cursorX = x
-	elseif cursorX > x + width then
-		cursorX = x + width
-	end
-	if cursorY < y then
-		cursorY = y
-	elseif cursorY > y + height then
-		cursorY = y + height
-	end
-	return cursorX, cursorY
+	local width = self.scissor.width
+	local height = self.scissor.height
+
+	return lume.clamp(cursorX, 0, width), lume.clamp(cursorY, 0, height)
 end
 
 function Camera:print(string, x, y)


### PR DESCRIPTION
Before this change, we limited the cursor of player 2 to the right half of the screen. For example, for an 800x600 screen, 400 ≤ x ≤ 800. However, this doesn't work because we now render each player's viewport to a canvas, where the top left corner is normalized to 0, 0.

Now, player's cursors are limited to 0 to the width and height of the screen.