### PR TITLE
Prevent the consolereader thread from hanging on quit

### DIFF
--- a/src/console.lua
+++ b/src/console.lua
@@ -1,6 +1,7 @@
 local reader = love.thread.newThread("consolereader.lua")
 local input = love.thread.newChannel()
-reader:start(input)
+local done = love.thread.newChannel()
+reader:start(input, done)
 
 local console = {
 	sleeptime = 0,
@@ -45,6 +46,10 @@ function console.repl(dt)
 			end
 		end
 	end
+end
+
+function console.quit()
+	done:push(true)
 end
 
 return console

--- a/src/consolereader.lua
+++ b/src/consolereader.lua
@@ -1,5 +1,5 @@
-local input = ...
+local input, done = ...
 
-while true do
+while not done:pop() do
 	input:push(io.read())
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -2,6 +2,7 @@ require("class")
 local MainMenu = require("gamestates/mainMenu")
 local Settings = require("settings")
 local StackManager = require("stackManager")
+local console = require("console")
 local enabledFunctions = require("gamestates/enabledFunctions")
 local log = require("log")
 
@@ -63,4 +64,8 @@ function love.keypressed(key)
 	if key == "f11" then love.window.setFullscreen(not love.window.getFullscreen(), "desktop") end
 
 	state.keypressed(key)
+end
+
+function love.quit()
+	console.quit()
 end


### PR DESCRIPTION
The infinite loop of the consolereader thread would continue forever even after the main thread was done. This made it impossible to fully quit the game without sending a KILL signal.

Now the reader thread will break out of the loop when the game exits, but it will still wait for one last line of input. Pressing enter in the terminal will end it.

I haven't found a way to wake up the thread from io.read() so that it can notice that it should quit right away. Something clever you can do with threads waiting on input from a socket is to just write to the socket. But writing to stdin in Lua blocks, causing the whole game to hang. Closing stdin might work, but Lua is hardcoded to prevent closing stdin, stdout, and stderr (I checked the source code and found the answer in liolib.c). So we'll just have to live with pressing enter one more time for now.