### PR TITLE
Simplify the build camera slightly

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -124,7 +124,7 @@ function Player:buttonpressed(source, button, debugmode)
 
 				-- TODO: Yikes, this is bad! It's just a proof
 				-- of concept. Delete or refactor.
-				if self.selected.build and self.selected.build.mode == 4 then
+				if self.selected.build and self.selected.build.structure then
 					self.camera.body = self.selected.build.structure.body
 				end
 


### PR DESCRIPTION
The player doesn't actually need to know what build mode we're in to move the camera to the structure we're building on. It just needs to know if there's a structure that we're building on.

This is only a tiny step in the right direction. It's still a bad sign that the player needs so many dots to get the data it needs:

    self.camera.body = self.selected.build.structure.body

All of those dots mean that the player has to be aware of the internal structure of some object, and a change in any of them could break this code. I'm still studying selection.lua and build.lua to see how this can be improved.