### PR TITLE
Fix screen splitting for wider screens

### DIFF
--- a/src/screen.lua
+++ b/src/screen.lua
@@ -15,10 +15,23 @@ end
 
 function Screen:arrange(screenWidth, screenHeight)
 	local n = #self.cameras
-	local screenArea = screenWidth * screenHeight
-	local cameraArea = screenArea / n
-	local columns = math.ceil(screenWidth/math.sqrt(cameraArea)-0.5)
-	local rows = math.ceil(n/columns)
+	local columns, rows = 1, 1
+	for i = 1, n do
+		if i > columns * rows then
+			if screenWidth / columns > screenHeight / rows then
+				columns = columns + 1
+			else
+				rows = rows + 1
+			end
+		end
+	end
+
+	if columns > rows then
+		columns = math.min(columns, math.ceil(n / rows))
+	else
+		rows = math.min(rows, math.ceil(n / columns))
+	end
+
 	local cameraWidth  = math.floor(screenWidth/columns)
 	local cameraHeight = math.floor(screenHeight/rows)
 	for i, camera in ipairs(self.cameras) do


### PR DESCRIPTION
The old algorithm for splitting a screen based on the number of players had problems. It worked fine for a more square 4:3 aspect ratio screen, but for widescreen ratios, it ran into problems after 3 players. For 4 players, it would add a third column to make a 3x2 grid.

On my DevTerm with its super wide 16:6 ratio, it ran into problems with only a single player. For 1 player, it would split the screen into two columns.

The new iterative algorithm only adds a new column or row when necessary, and it tries to balance the columns and rows at the end to make the grid sections as square as possible.

Screenshot of old behavior:

![Screenshot from 2023-10-09 16-51-39](https://github.com/synthein/synthein/assets/2390950/2e4cc699-7cdc-4ee8-80be-215142e79d57)

Charts of the old behavior (thanks Sympy and Matplotlib):

![image](https://github.com/synthein/synthein/assets/2390950/9cc52244-cfa6-4c14-b004-1b087f4d097f)

![image](https://github.com/synthein/synthein/assets/2390950/f4f9890b-8b3a-48c8-8719-e830e5d69a9a)
