### PR TITLE
Try to clean up player camera movement

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -122,12 +122,6 @@ function Player:buttonpressed(source, button, debugmode)
 					self.cursorY)
 				self.selected:pressed(cursorX, cursorY, order)
 
-				-- TODO: Yikes, this is bad! It's just a proof
-				-- of concept. Delete or refactor.
-				if self.selected.build and self.selected.build.structure then
-					self.camera.body = self.selected.build.structure.body
-				end
-
 			elseif order == "playerMenu" then
 				if debugmode then
 					self.menu = true
@@ -147,15 +141,16 @@ function Player:buttonreleased(source, button)
 	local cursorX, cursorY = self.camera:getWorldCoords(self.cursorX, self.cursorY)
 	if order == "build" then
 		self.selected:released(cursorX, cursorY)
-
-		-- TODO: Yikes part 2!
-		if self.selected.build == nil then
-			self.camera.body = self.ship.body
-		end
 	end
 end
 
 function Player:draw(debugmode)
+	if self.selected:isBuildingOnStructure() then
+		self.camera.body = self.selected.structure.body
+	else
+		self.camera.body = self.ship.body
+	end
+
 	self.camera:drawPlayer(self, debugmode)
 end
 

--- a/src/selection.lua
+++ b/src/selection.lua
@@ -141,6 +141,10 @@ function Selection:released(cursorX, cursorY)
 	end
 end
 
+function Selection:isBuildingOnStructure()
+	return self.build and self.build.structure
+end
+
 function Selection:draw(cursorX, cursorY)
 	local structure = self.structure
 	local part = self.part


### PR DESCRIPTION
1. Reduce the knowledge that player.lua has to have about its sub-sub-objects.
2. Consolidate the number of places in player.lua that have to make changes to the camera body.