### PR TITLE
Draw the selection cursor on the screen

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -311,6 +311,7 @@ function Camera:drawPlayer(player, debugmode)
 	
 	local playerDrawPack = {}
 	playerDrawPack.compassAngle = compassAngle
+	playerDrawPack.camera = {x = self.x, y = self.y, self.scissor.width, self.scissor.height}
 	playerDrawPack.cursor = {x = player.cursorX, y = player.cursorY, image = player.cursor}
 	playerDrawPack.menu = player.menu
 	playerDrawPack.partSelector = player.partSelector

--- a/src/hud.lua
+++ b/src/hud.lua
@@ -79,7 +79,7 @@ local function drawCompass(viewPort, compassAngle)
 	)
 end
 
-local function drawSelection(selection, cursor)
+local function drawSelection(selection, camera, cursor)
 	local structure = selection.structure
 	local part = selection.part
 	local build = selection.build
@@ -130,8 +130,8 @@ local function drawSelection(selection, cursor)
 
 			love.graphics.draw(
 				cursor.image,
-				x, y, angle,
-				1/20, 1/20,
+				camera.x+x, camera.y+y, angle,
+				1, 1,
 				halfCursorWidth, halfCursorWidth)
 		end
 	end
@@ -142,8 +142,8 @@ local function drawSelection(selection, cursor)
 		local angle = body:getAngle()
 		love.graphics.draw(
 			cursor.image,
-			x, y, angle,
-			1/20, 1/20,
+			camera.x+x, camera.y+y, angle,
+			1, 1,
 			halfCursorWidth, halfCursorWidth)
 	end
 end
@@ -156,9 +156,7 @@ function Hud:draw(playerDrawPack, viewPort, compassAngle)
 
 	drawCompass(viewPort, playerDrawPack.compassAngle)
 	if playerDrawPack.selection then
-		-- TODO: At what point do the cursor coordinates need to be world
-		-- coordinates?
-		drawSelection(playerDrawPack.selection, playerDrawPack.cursor)
+		drawSelection(playerDrawPack.selection, playerDrawPack.camera, playerDrawPack.cursor)
 	end
 
 	-- Draw the cursor.


### PR DESCRIPTION
Now the cursor appears on the screen, but the position is still wrong. We need to do some of the translations that we do for world objects (invert Y axis, rotate based on camera rotation, etc.) but not all (we don't want to scale the cursor and circle menu to be tiny when you zoom out).