### PR TITLE
Translate the selection cursor so that it's drawn on the part

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -311,12 +311,13 @@ function Camera:drawPlayer(player, debugmode)
 	
 	local playerDrawPack = {}
 	playerDrawPack.compassAngle = compassAngle
-	playerDrawPack.camera = {x = self.x, y = self.y, self.scissor.width, self.scissor.height}
+	playerDrawPack.camera = {x = self.x, y = self.y, width = self.scissor.width, height = self.scissor.height}
 	playerDrawPack.cursor = {x = player.cursorX, y = player.cursorY, image = player.cursor}
 	playerDrawPack.menu = player.menu
 	playerDrawPack.partSelector = player.partSelector
 	playerDrawPack.gameOver = self.gameOver
 	playerDrawPack.selection = player.selected
+	playerDrawPack.zoom = self.zoom
 
 	love.graphics.setScissor(unpack(scissor))
 

--- a/src/hud.lua
+++ b/src/hud.lua
@@ -79,7 +79,7 @@ local function drawCompass(viewPort, compassAngle)
 	)
 end
 
-local function drawSelection(selection, camera, cursor)
+local function drawSelection(selection, camera, cursor, zoom)
 	local structure = selection.structure
 	local part = selection.part
 	local build = selection.build
@@ -127,10 +127,12 @@ local function drawSelection(selection, camera, cursor)
 			local l = StructureMath.addDirectionVector(vec, vec[3], .5)
 			local x, y = body:getWorldPoint(l[1], l[2])
 			local angle = body:getAngle()
+			local screenX = camera.width/2 + (x - camera.x) * zoom
+			local screenY = camera.height/2 + (y - camera.y) * -zoom
 
 			love.graphics.draw(
 				cursor.image,
-				camera.x+x, camera.y+y, angle,
+				screenX, screenY, -angle,
 				1, 1,
 				halfCursorWidth, halfCursorWidth)
 		end
@@ -140,9 +142,12 @@ local function drawSelection(selection, camera, cursor)
 		local body = assign.modules.hull.fixture:getBody()
 		local x, y  = body:getPosition()
 		local angle = body:getAngle()
+		local screenX = camera.width/2 + (x - camera.x) * zoom
+		local screenY = camera.height/2 + (y - camera.y) * -zoom
+
 		love.graphics.draw(
 			cursor.image,
-			camera.x+x, camera.y+y, angle,
+			screenX, screenY, -angle,
 			1, 1,
 			halfCursorWidth, halfCursorWidth)
 	end
@@ -156,7 +161,7 @@ function Hud:draw(playerDrawPack, viewPort, compassAngle)
 
 	drawCompass(viewPort, playerDrawPack.compassAngle)
 	if playerDrawPack.selection then
-		drawSelection(playerDrawPack.selection, playerDrawPack.camera, playerDrawPack.cursor)
+		drawSelection(playerDrawPack.selection, playerDrawPack.camera, playerDrawPack.cursor, playerDrawPack.zoom)
 	end
 
 	-- Draw the cursor.


### PR DESCRIPTION
Now the cursor is drawn in the right place. It takes zoom into consideration. It does not handle camera rotation. The transation should probably be moved to camera.lua or somewhere, but now we can see what components need to translate and what information we need.