### PR TITLE
Move selection translations to camera.lua

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -277,7 +277,7 @@ end
 
 function Camera:drawPlayer(player, debugmode)
 	local compassAngle = 0
-	
+
 	--TODO this no longer makes sense
 	local body = self.body
 	if body then
@@ -287,7 +287,7 @@ function Camera:drawPlayer(player, debugmode)
 		else
 			self.x, self.y = body:getPosition()
 			self.angle = player.isCameraAngleFixed and 0 or body:getAngle()
-					
+
 			local point = {0,0}
 
 			local leader = (player.ship.corePart or {}).leader
@@ -308,7 +308,7 @@ function Camera:drawPlayer(player, debugmode)
 	local viewPort = {}
 	viewPort.width = scissor.width
 	viewPort.height = scissor.height
-	
+
 	local playerDrawPack = {}
 	playerDrawPack.compassAngle = compassAngle
 	playerDrawPack.camera = {x = self.x, y = self.y, width = self.scissor.width, height = self.scissor.height}
@@ -327,13 +327,23 @@ function Camera:drawPlayer(player, debugmode)
 	love.graphics.rotate(self.angle)
 	love.graphics.scale(self.zoom, -self.zoom)
 	love.graphics.translate(- self.x, - self.y)
-	
+
 	self:drawWorldObjects(player, debugmode)
+
+	--Set translation for hud elements that point to world objects
+	love.graphics.origin()
+	love.graphics.translate(scissor.x, scissor.y)
+	love.graphics.translate(scissor.width/2, scissor.height/2)
+	love.graphics.rotate(self.angle)
+	love.graphics.scale(self.zoom, -self.zoom)
+	love.graphics.translate(- self.x, - self.y)
+
+	self.hud:drawLabels(playerDrawPack, viewPort)
 
 	--Set translation for hud
 	love.graphics.origin()
 	love.graphics.translate(scissor.x, scissor.y)
-	
+
 	--Draw shields
 	love.graphics.setColor(31/255, 63/255, 143/255, 95/255)
 	local drawPoints = love.graphics.points
@@ -341,9 +351,9 @@ function Camera:drawPlayer(player, debugmode)
 		drawPoints(unpack(list))
 	end
 	love.graphics.setColor(1, 1, 1, 1)
-	
+
 	self.hud:draw(playerDrawPack, viewPort)
-	
+
 	--Reset graphics translation
 	love.graphics.origin()
 

--- a/src/selection.lua
+++ b/src/selection.lua
@@ -21,7 +21,8 @@ function Selection.create(world, team)
 	return self
 end
 
-local function angleToIndex(angle, length)
+-- TODO: Move this to CircleMenu?
+function Selection.angleToIndex(angle, length)
 	local index = math.floor(((-angle/math.pi + 0.5) * length + 1)/2 % length + 1)
 	return index
 end
@@ -109,7 +110,7 @@ function Selection:released(cursorX, cursorY)
 				local x, y = body:getWorldPoints(l[1], l[2])
 				local strength = part:getMenu()
 				local newAngle = vector.angle(cursorX - x, cursorY - y)
-				local index = angleToIndex(newAngle, #strength)
+				local index = Selection.angleToIndex(newAngle, #strength)
 				local option = self.part:runMenu(index, body)
 				if option == "assign" then
 					self.assign = self.part


### PR DESCRIPTION
Now camera.lua knows about 3 kinds of transformations:

1. objects in the world
2. hud elements drawn to fixed positions on the screen
3. hud elements that point to a world object

The third type is new. It scales, rotates, translates so that the object is always positioned over the world object it refers to, but it still keeps the normal scale, ignoring zoom.

This last feature isn't quite done yet. I cheat it a bit by reversing the effects of scaling manually on all love.draw calls inside the drawLabels() function. This should be fixable in the future though.