### PR TITLE
Move angleToIndex to CircleMenu

### DIFF
--- a/src/circleMenu.lua
+++ b/src/circleMenu.lua
@@ -15,8 +15,7 @@ function CircleMenu.indexToAngle(index, division, startAngle)
 end
 
 function CircleMenu.angleToIndex(angle, length)
-	local index = math.floor(((-angle/math.pi + 0.5) * length + 1)/2 % length + 1)
-	return index
+	return math.floor(((-angle/math.pi + 0.5) * length + 1)/2 % length + 1)
 end
 
 function CircleMenu.draw(x, y, angle, size, strength, labels)

--- a/src/circleMenu.lua
+++ b/src/circleMenu.lua
@@ -14,6 +14,11 @@ function CircleMenu.indexToAngle(index, division, startAngle)
 	return startAngle - math.pi * (-0.5 + ((index) * 2 - 1) / division)
 end
 
+function CircleMenu.angleToIndex(angle, length)
+	local index = math.floor(((-angle/math.pi + 0.5) * length + 1)/2 % length + 1)
+	return index
+end
+
 function CircleMenu.draw(x, y, angle, size, strength, labels)
 	local division = #strength
 

--- a/src/hud.lua
+++ b/src/hud.lua
@@ -1,7 +1,6 @@
 local CanvasUtils = require("widgets/canvasUtils")
 local CircleMenu = require("circleMenu")
 local ListSelector = require("widgets/listSelector")
-local Selection = require("selection")
 local StructureMath = require("world/structureMath")
 local vector = require("vector")
 
@@ -110,7 +109,7 @@ local function drawSelection(selection, cursor, zoom)
 			local x, y = body:getWorldPoints(partX, partY)
 			strength, labels = part:getMenu()
 			local newAngle = vector.angle(cursor.x - x, cursor.y - y)
-			local index = Selection.angleToIndex(newAngle, #strength)
+			local index = CircleMenu.angleToIndex(newAngle, #strength)
 			if strength[index] == 1 then
 				strength[index] = 2
 			end

--- a/src/selection.lua
+++ b/src/selection.lua
@@ -1,5 +1,6 @@
 local StructureMath = require("world/structureMath")
 local Building = require("building")
+local CircleMenu = require("circleMenu")
 local vector = require("vector")
 
 local Selection = {}
@@ -19,12 +20,6 @@ function Selection.create(world, team)
 	self.assign = nil
 
 	return self
-end
-
--- TODO: Move this to CircleMenu?
-function Selection.angleToIndex(angle, length)
-	local index = math.floor(((-angle/math.pi + 0.5) * length + 1)/2 % length + 1)
-	return index
 end
 
 function Selection:pressed(cursorX, cursorY, order)
@@ -110,7 +105,7 @@ function Selection:released(cursorX, cursorY)
 				local x, y = body:getWorldPoints(l[1], l[2])
 				local strength = part:getMenu()
 				local newAngle = vector.angle(cursorX - x, cursorY - y)
-				local index = Selection.angleToIndex(newAngle, #strength)
+				local index = CircleMenu.angleToIndex(newAngle, #strength)
 				local option = self.part:runMenu(index, body)
 				if option == "assign" then
 					self.assign = self.part


### PR DESCRIPTION
In now lives next to indexToAngle. The places that use it don't necessarily use a circle menu, but it kind of makes sense for the logic to be here or in some other neutral place.