### PR TITLE
Convert userdata connection message to a debug log

### DIFF
--- a/src/world/structure.lua
+++ b/src/world/structure.lua
@@ -1,11 +1,12 @@
-local GridTable = require("gridTable")
-local StructureMath = require("world/structureMath")
-local StructureParser = require("world/structureParser")
-local Location = require("world/location")
 local Engine = require("world/shipparts/modules/engine")
+local GridTable = require("gridTable")
 local Gun = require("syntheinrust").shipparts.modules.gun
+local Location = require("world/location")
 local MissileLauncher = require("syntheinrust").shipparts.modules.missileLauncher
 local Shield = require("world/shipparts/modules/shield")
+local StructureMath = require("world/structureMath")
+local StructureParser = require("world/structureParser")
+local log = require("log")
 
 local Structure = class(require("world/worldObjects"))
 
@@ -58,8 +59,7 @@ function Structure:__create(worldInfo, location, data, appendix)
 
 	local userDataParent = {
 		__index = function(t, key)
-			print("Undesirable connection in structure body userdata. Key:", key)
-			print(debug.traceback())
+			log:debug("Undesirable connection in structure body userdata. Key:%s\n%s", key, debug.traceback())
 			return self[key]
 		end
 	}


### PR DESCRIPTION
This message is useful, but it's also nice to be able to turn it off. It's still on by default, because the ./run command starts the game in debug mode. But it's possible to turn it off by leaving debug mode with f12. This makes it easier to see other messages, such as some log:info messages I'm using for something I'm working on.