### PR TITLE
Show the correct sides as connectable when building

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -93,12 +93,13 @@ local function drawSelection(selection, cursor, zoom)
 		if build then
 			menuRotation = body:getAngle()
 			strength = {}
+			local indexReverse = {1, 4, 3, 2}
 			local x, y = body:getWorldPoints(partX, partY)
 			local menuToCursorAngle = vector.angle(cursor.worldX - x, cursor.worldY - y)
 			local partSide = CircleMenu.angleToIndex(-menuRotation + menuToCursorAngle, 4)
 			local l = {partX, partY}
 			for i = 1,4 do
-				l[3] = i
+				l[3] = indexReverse[i]
 				local _, partB, connection = structure:testEdge(l)
 				local connectable = not partB and connection
 				local highlight = i == partSide


### PR DESCRIPTION
I previously deleted indexReverse thinking that it wasn't needed. It is still partially needed, but only for finding connectable sides and not for drawing the circle menu.

Before:

![Screenshot from 2024-02-29 15-41-17](https://github.com/synthein/synthein/assets/2390950/d3625049-597a-4c6a-98b9-c7c434aca5ac)

After:

![Screenshot from 2024-02-29 15-41-45](https://github.com/synthein/synthein/assets/2390950/19d81104-cd8c-443b-a67b-231353d37fbd)

