### PR TITLE
Allow logging nil values

### DIFF
--- a/src/log.lua
+++ b/src/log.lua
@@ -21,8 +21,20 @@ end
 
 local function out(message, ...)
   local processed = {}
-  for i, v in pairs({...}) do
-    processed[i] = type(v) == "table" and texpand(v) or v
+
+  for i=1,select('#', ...) do
+    local oldval = select(i, ...)
+    local newval
+
+    if type(oldval) == "table" then
+      newval = texpand(oldval)
+    elseif type(oldval) == "nil" then
+      newval = "nil"
+    else
+      newval = oldval
+    end
+
+    processed[i] = newval
   end
   io.stderr:write(os.date() .. " " .. string.format(message, unpack(processed)) .. "\n")
 end


### PR DESCRIPTION
Previously this would fail in the case where val was nil:

	log:info("I wonder what the value of this is: %s", val)

Now we convert nil values to the string "nil" so that string.format() sees them.