### PR TITLE
Fix crash when particles are in the world

### DIFF
--- a/src/world/particles.lua
+++ b/src/world/particles.lua
@@ -7,7 +7,8 @@ local PhysicsReferences = require("world/physicsReferences")
 Particles.type = "particles"
 
 function Particles:__create(worldInfo, location, data, appendix)
-	self.physicsShape = love.physics.newRectangleShape(40, 40)
+	self.body:setUserData({type = "particles"})
+	self.physicsShape = love.physics.newRectangleShape(2, 2)
 	self.fixture = love.physics.newFixture(self.body, self.physicsShape)
 	self.fixture:setUserData(self)
 	PhysicsReferences.setFixtureType(self.fixture, "visual")


### PR DESCRIPTION
In 82302b3, I added an assumption that all world objects have a body that has user data set on it. Most do, but particles previously did not have a user data object set on their body, only a fixture attached to the body. This caused an index into nil error that crashed the game whenever particles were in the world, such as when a part is destroyed.

We want all bodies in the world to have user data for other reasons, so the fix is to make sure particles have user data.

Unrelated: Also make the size of the particle fixture the right size. It should be 2 blocks by 2 blocks, whereas it was previously 40 pixels by 40 pixels. This doesn't effect anything really, but it did cause weird behavior when interacting with other bugs.