### PR TITLE
Don't display the blue screen of death in headless mode

### DIFF
--- a/src/conf.lua
+++ b/src/conf.lua
@@ -41,6 +41,10 @@ function love.conf(t)
 			love.window = stub()
 			love.graphics = stub()
 			love.audio = stub()
+
+			love.errorhandler = function(msg)
+				print(debug.traceback("Error: " .. tostring(msg), 3))
+			end
 		end
 	end
 end


### PR DESCRIPTION
The blue screen of death keeps the game running so the user can see the
error message, but we want the game to print the message on standard
out and quit immediately so we can move on to the next test.