### PR TITLE
Prevent the unit tests from hanging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ luacheck:
 	find src -name '*.lua' -not -path 'src/vendor/*' -exec luacheck --no-unused-args {} +
 
 test:
-	love src --unit-tests
+	printf '\n' | love src --unit-tests
 	test/init.sh
 
 .PHONY: appimage check clean dep love luacheck macos rust test windows


### PR DESCRIPTION
The unit test suite used to hang, waiting on console input. Just like when you run the game normally you need to press enter once to stop the console, the tests need a newline. This moves the console reader past the line where it block waiting for input and allows it to check to see if it should quit.