### PR TITLE
Replace return with exit in test scripts

### DIFF
--- a/test/test_all_scenes.sh
+++ b/test/test_all_scenes.sh
@@ -6,6 +6,6 @@ find src/res/scenes -name '*.txt' | sed -E 's|.*/([[:alnum:]_-]+).txt|\1|' | whi
 	if ! echo "quit()" | love src $extra_args --scene "$scene"
 	then
 		printf "FAILED: scene %s crashed\n" "$scene"
-		return 1
+		exit 1
 	fi
 done

--- a/test/test_breakage.sh
+++ b/test/test_breakage.sh
@@ -16,5 +16,5 @@ num_objects_after=$(sed -n 2p "$output")
 if ! [ "$num_objects_before" -eq 2 -a "$num_objects_after" -eq 3 ]; then
 	printf "FAILED: expected 2 objects before breakage (actual: %s) " "$num_objects_before"
 	printf "and 3 objects after (actual: %s)\n" "$num_objects_after"
-	return 1
+	exit 1
 fi

--- a/test/test_disconnect_parts.sh
+++ b/test/test_disconnect_parts.sh
@@ -16,5 +16,5 @@ num_objects_after=$(sed -n 2p "$output")
 if ! [ "$num_objects_before" -eq 2 -a "$num_objects_after" -eq 4 ]; then
 	printf "FAILED: expected 2 objects before disconnect (actual: %s) " "$num_objects_before"
 	printf "and 4 objects after (actual: %s)\n" "$num_objects_after"
-	return 1
+	exit 1
 fi

--- a/test/test_disconnect_parts_from_active_ship.sh
+++ b/test/test_disconnect_parts_from_active_ship.sh
@@ -16,5 +16,5 @@ num_objects_after=$(sed -n 2p "$output")
 if ! [ "$num_objects_before" -eq 2 -a "$num_objects_after" -eq 3 ]; then
 	printf "FAILED: expected 2 objects before disconnect (actual: %s) " "$num_objects_before"
 	printf "and 3 objects after (actual: %s)\n" "$num_objects_after"
-	return 1
+	exit 1
 fi

--- a/test/test_heal.sh
+++ b/test/test_heal.sh
@@ -16,5 +16,5 @@ EOF
 actual=$(cat "$output")
 if ! [ "$actual" -gt 1 ]; then
 	printf "FAILED: expected %s > 1\n" "$actual"
-	return 1
+	exit 1
 fi

--- a/test/test_missile_area_of_effect.sh
+++ b/test/test_missile_area_of_effect.sh
@@ -15,9 +15,9 @@ output_after=$(sed -n 2p "$output")
 
 if ! [ "$output_before" -eq 16 ]; then
 	printf "FAILED: expected %s = 16\n" "$output_before"
-	return 1
+	exit 1
 fi
 if ! [ "$output_after" -eq 11 ]; then
 	printf "FAILED: expected %s = 11\n" "$output_after"
-	return 1
+	exit 1
 fi

--- a/test/test_spawn.sh
+++ b/test/test_spawn.sh
@@ -17,5 +17,5 @@ output_after=$(sed -n 2p "$output")
 
 if ! [ "$output_after" -gt "$output_before" ]; then
 	printf "FAILED: expected %s > %s\n" "$output_after" "$output_before"
-	return 1
+	exit 1
 fi


### PR DESCRIPTION
This is a trivial change, but it's not syntactically valid to use return here because return only makes sense in functions and sourced files.