### PR TITLE
Write error messages to stderr

### DIFF
--- a/src/conf.lua
+++ b/src/conf.lua
@@ -43,7 +43,7 @@ function love.conf(t)
 			love.audio = stub()
 
 			love.errorhandler = function(msg)
-				print(debug.traceback("Error: " .. tostring(msg), 3))
+				io.stderr:write(debug.traceback("Error: " .. tostring(msg), 3))
 			end
 		end
 	end


### PR DESCRIPTION
During tests, output is captured and stored in a temporary file that
the test code can inspect and make assertions about. We don't want
error messages and stack traces to go to the same place; that causes
the errors to get swallowed and deleted after the test. Errors should
be printed to the terminal after the test. The test runner already
captures and prints standard error, so printing to standard error
has the intended effect.