### PR TITLE
Fix crash when missiles are in the world

### DIFF
--- a/src/world/missile.lua
+++ b/src/world/missile.lua
@@ -9,6 +9,8 @@ local Missile = class(require("world/worldObjects"))
 Missile.type = "missile"
 
 function Missile:__create(worldInfo, location, data, appendix)
+	self.body:setUserData({type = "missile"})
+
 	self.events = worldInfo.events
 
 	self.thrust = 10

--- a/test/test_missile_area_of_effect.sh
+++ b/test/test_missile_area_of_effect.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene test-missile2 > "$output" 2>/dev/null <<EOF
+love src $extra_args --scene test-missile2 > "$output" <<EOF
 return #world.objects
 sleep(2)
 return #world.objects


### PR DESCRIPTION
Missiles were missing a user data object on their body, which became
required recently.