### PR TITLE
Fix crash in headless mode

### DIFF
--- a/src/tests/stub.lua
+++ b/src/tests/stub.lua
@@ -1,5 +1,5 @@
 return function()
-  local stub = {}
+  local stub = {stub = true}
   return setmetatable(stub, {
     __index = function() return stub end,
     __call = function() return stub, stub end,
@@ -7,5 +7,6 @@ return function()
     __sub = function() return 1 end,
     __mul = function() return 1 end,
     __div = function() return 1 end,
+    __lt = function() return true end,
   })
 end

--- a/src/widgets/canvasUtils.lua
+++ b/src/widgets/canvasUtils.lua
@@ -32,14 +32,14 @@ function CanvasUtils.generateScaleTable(horRef, verRef, horOff, verOff)
 	else
 		verOff = 0.5
 	end
-	
+
 	return {horRef, verRef, horOff, verOff}
 end
 
 function CanvasUtils.copyCanvas(source, x, y, scaleTable, color, destination)
 	local horRef, verRef, horOff, verOff = unpack(scaleTable)
 	love.graphics.setColor(unpack(color or {1, 1, 1}))
-	
+
 	local srcWidth, srcHeight = source:getDimensions()
 	local desWidth, desHeight = (destination or love.window):getDimensions()
 
@@ -47,9 +47,9 @@ function CanvasUtils.copyCanvas(source, x, y, scaleTable, color, destination)
 
 	local x = x + desWidth  * horRef - srcWidth  * horOff
 	local y = y + desHeight * verRef - srcHeight * verOff
-	
+
 	love.graphics.draw(source, x, y)
-	
+
 	love.graphics.setCanvas()
 end
 
@@ -60,9 +60,9 @@ function CanvasUtils.isWithin(curX, curY, canX, canY, source, destination, scale
 
 	local x = curX - canX - desWidth  * horRef + srcWidth  * horOff
 	local y = curY - canY - desHeight * verRef + srcHeight * verOff
-	
+
 	local within = 0 <= x and x <= srcWidth and 0 <= y and y <= srcWidth
-	
+
 	return within, x, y
 end
 


### PR DESCRIPTION
The game was crashing in headless mode because of a comparison with a stub in canvasUtils. canvasUtils.isWithin() gets the dimensions of a canvas and then does comparisons on it. Since canvases are stubbed, getDimensions returns a stub, which was not comparable until now.

Also, add the field `stub = true` to stubs to make it easier to notice them when debugging.

I'll leave a marker.
Lost ones will see it and say:
Ah, this is a stub.