### PR TITLE
Reorder output for failed scene tests

### DIFF
--- a/test/test_all_scenes.sh
+++ b/test/test_all_scenes.sh
@@ -3,9 +3,9 @@
 extra_args="$1"
 
 find src/res/scenes -name '*.txt' | sed -E 's|.*/([[:alnum:]_-]+).txt|\1|' | while IFS= read -r scene; do
-	if ! echo "quit()" | love src $extra_args --scene "$scene"
+	if ! output=$(echo "quit()" | love src $extra_args --scene "$scene" 2>&1)
 	then
-		printf "FAILED: scene %s crashed\n" "$scene"
+		printf "FAILED: scene %s crashed:\n%s" "$scene" "$output"
 		exit 1
 	fi
 done

--- a/test/test_all_scenes.sh
+++ b/test/test_all_scenes.sh
@@ -5,7 +5,7 @@ extra_args="$1"
 find src/res/scenes -name '*.txt' | sed -E 's|.*/([[:alnum:]_-]+).txt|\1|' | while IFS= read -r scene; do
 	if ! output=$(echo "quit()" | love src $extra_args --scene "$scene" 2>&1)
 	then
-		printf "FAILED: scene %s crashed:\n%s" "$scene" "$output"
+		printf "FAILED: scene %s crashed:\n%s\n" "$scene" "$output"
 		exit 1
 	fi
 done


### PR DESCRIPTION
Previously when the test_all_scenes test caught a scene that failed, it was hard to see which scene failed. The name of the scene that failed was at the end of the stack trace and not on a separate line as it should be:

	test/test_all_scenes.sh: Error: controls.lua:14: bad argument #1 to 'isDown' (Joystick expected, got string)
	stack traceback:
		[C]: in function 'isDown'
		controls.lua:14: in function 'getOrders'
		player.lua:70: in function 'handleInput'
		gamestates/inGame.lua:217: in function 'update'
		main.lua:144: in function 'update'
		[love "callbacks.lua"]:162: in function <[love "callbacks.lua"]:144>
		[C]: in function 'xpcall'
		[love "boot.lua"]:377: in function <[love "boot.lua"]:344>FAILED: scene startSceneTwoPlayer crashed

Now we capture the stack trace and put it after the name of the scene:

	test/test_all_scenes.sh: FAILED: scene startSceneTwoPlayer crashed:
	Error: controls.lua:14: bad argument #1 to 'isDown' (Joystick expected, got string)
	stack traceback:
		[C]: in function 'isDown'
		controls.lua:14: in function 'getOrders'
		player.lua:70: in function 'handleInput'
		gamestates/inGame.lua:217: in function 'update'
		main.lua:144: in function 'update'
		[love "callbacks.lua"]:162: in function <[love "callbacks.lua"]:144>
		[C]: in function 'xpcall'
		[love "boot.lua"]:377: in function <[love "boot.lua"]:344>