### PR TITLE
Add smooth camera movement

### DIFF
--- a/src/animation.lua
+++ b/src/animation.lua
@@ -1,4 +1,3 @@
-
 local Animation = class()
 
 local funcs = {}
@@ -12,9 +11,18 @@ function Animation:__create(start, dest, duration, func)
   self.func = funcs[func]
 end
 
-function Animation:step(dt)
+function Animation:step(dt, dest)
+  if dest then
+    self.dest = dest
+  end
+
   self.elapsed = self.elapsed + dt
-  return self.func(self.start, self.dest, self.elapsed / self.duration)
+
+  local x = self.func(self.start[1], self.dest[1], self.elapsed / self.duration)
+  local y = self.func(self.start[2], self.dest[2], self.elapsed / self.duration)
+  local a = self.func(self.start[3], self.dest[3], self.elapsed / self.duration)
+
+  return x, y, a
 end
 
 function Animation:isDone()

--- a/src/animation.lua
+++ b/src/animation.lua
@@ -1,7 +1,8 @@
 local Animation = class()
 
-local funcs = {}
-function funcs.linear(s, d, r) return (d-s)*r + s end
+local funcs = {
+  linear = function(s, d, r) return (d-s)*r + s end
+}
 
 function Animation:__create(start, dest, duration, func)
   self.start = start

--- a/src/animation.lua
+++ b/src/animation.lua
@@ -1,0 +1,24 @@
+
+local Animation = class()
+
+local funcs = {}
+function funcs.linear(s, d, r) return (d-s)*r + s end
+
+function Animation:__create(start, dest, duration, func)
+  self.start = start
+  self.dest = dest
+  self.elapsed = 0
+  self.duration = duration
+  self.func = funcs[func]
+end
+
+function Animation:step(dt)
+  self.elapsed = self.elapsed + dt
+  return self.func(self.start, self.dest, self.elapsed / self.duration)
+end
+
+function Animation:isDone()
+  return self.elapsed >= self.duration
+end
+
+return Animation

--- a/src/camera.lua
+++ b/src/camera.lua
@@ -283,6 +283,14 @@ function Camera:drawWorldObjects(player, debugmode)
 	player.shieldPoints = player.camera:testPoints(testPointFunctions)
 end
 
+local function shortestPath(angle, newAngle)
+	local angleDiff = newAngle - angle
+	if angleDiff > math.pi then
+		angleDiff = angleDiff - 2*math.pi
+	end
+	return angle + angleDiff
+end
+
 function Camera:drawPlayer(player, debugmode)
 	local compassAngle = 0
 
@@ -294,7 +302,8 @@ function Camera:drawPlayer(player, debugmode)
 			self.gameOver = true
 		else
 			local newX, newY = body:getPosition()
-			local newAngle = player.isCameraAngleFixed and 0 or body:getAngle()
+			local newAngle = player.isCameraAngleFixed and 0 or body:getAngle() % (2*math.pi)
+			newAngle = shortestPath(self.angle, newAngle)
 			self.x = lume.lerp(self.x, newX, self.animationPercent)
 			self.y = lume.lerp(self.y, newY, self.animationPercent)
 			self.angle = lume.lerp(self.angle, newAngle, self.animationPercent)

--- a/src/camera.lua
+++ b/src/camera.lua
@@ -4,6 +4,8 @@ local Settings = require("settings")
 local mathext = require("syntheinrust").mathext
 local vector = require("vector")
 
+local lume = require("vendor/lume")
+
 local Camera = {}
 Camera.__index = Camera
 
@@ -14,6 +16,7 @@ function Camera.create()
 	self.x = 0
 	self.y = 0
 	self.angle = 0
+	self.animationPercent = 1
 	self.zoomInt = 8
 	self:adjustZoom(0)
 	self.scissor = {x = 0, y = 0, width = 0, height = 0}
@@ -25,6 +28,11 @@ function Camera.create()
 	self.hud = Hud()
 	
 	return self
+end
+
+function Camera:setTarget(target)
+	self.body = target
+	self.animationPercent = 0
 end
 
 function Camera:getWorldCoords(cursorX, cursorY)
@@ -285,8 +293,12 @@ function Camera:drawPlayer(player, debugmode)
 			self.body = nil
 			self.gameOver = true
 		else
-			self.x, self.y = body:getPosition()
-			self.angle = player.isCameraAngleFixed and 0 or body:getAngle()
+			local newX, newY = body:getPosition()
+			local newAngle = player.isCameraAngleFixed and 0 or body:getAngle()
+			self.x = lume.lerp(self.x, newX, self.animationPercent)
+			self.y = lume.lerp(self.y, newY, self.animationPercent)
+			self.angle = lume.lerp(self.angle, newAngle, self.animationPercent)
+			self.animationPercent = self.animationPercent + 0.1
 
 			local point = {0,0}
 

--- a/src/camera.lua
+++ b/src/camera.lua
@@ -16,7 +16,8 @@ function Camera.create()
 	self.x = 0
 	self.y = 0
 	self.angle = 0
-	self.animationPercent = 1
+	self.animationElapsed = 10
+	self.animationDuration = 10
 	self.zoomInt = 8
 	self:adjustZoom(0)
 	self.scissor = {x = 0, y = 0, width = 0, height = 0}
@@ -32,7 +33,7 @@ end
 
 function Camera:setTarget(target)
 	self.body = target
-	self.animationPercent = 0
+	self.animationElapsed = 0
 end
 
 function Camera:getWorldCoords(cursorX, cursorY)
@@ -291,6 +292,14 @@ local function shortestPath(angle, newAngle)
 	return angle + angleDiff
 end
 
+function Camera:update(dt)
+	if self.animationElapsed < self.animationDuration then
+		self.animationElapsed = self.animationElapsed + dt
+	else
+		self.animationElapsed = self.animationDuration
+	end
+end
+
 function Camera:drawPlayer(player, debugmode)
 	local compassAngle = 0
 
@@ -303,11 +312,11 @@ function Camera:drawPlayer(player, debugmode)
 		else
 			local newX, newY = body:getPosition()
 			local newAngle = player.isCameraAngleFixed and 0 or body:getAngle() % (2*math.pi)
+			local animationPercent = self.animationElapsed/self.animationDuration
 			newAngle = shortestPath(self.angle, newAngle)
-			self.x = lume.lerp(self.x, newX, self.animationPercent)
-			self.y = lume.lerp(self.y, newY, self.animationPercent)
-			self.angle = lume.lerp(self.angle, newAngle, self.animationPercent)
-			self.animationPercent = self.animationPercent + 0.1
+			self.x = lume.lerp(self.x, newX, animationPercent)
+			self.y = lume.lerp(self.y, newY, animationPercent)
+			self.angle = lume.lerp(self.angle, newAngle, animationPercent)
 
 			local point = {0,0}
 

--- a/src/camera.lua
+++ b/src/camera.lua
@@ -30,14 +30,11 @@ end
 
 function Camera:setTarget(target)
 	local duration = 1
-
 	local x, y = self.body:getPosition()
 	local angle = self.body:getAngle()
-	self.body = target
 
-	self.xanim = Animation(x, target:getX(), duration, "linear")
-	self.yanim = Animation(y, target:getY(), duration, "linear")
-	self.aanim = Animation(angle, target:getAngle(), duration, "linear")
+	self.body = target
+	self.pan = Animation({x, y, angle}, {target:getX(), target:getY(), target:getAngle()}, duration, "linear")
 end
 
 function Camera:getWorldCoords(cursorX, cursorY)
@@ -316,37 +313,12 @@ function Camera:update(player, dt)
 			player.isCameraAngleFixed and 0 or body:getAngle() % (2*math.pi)
 		)
 
-		if self.xanim then
-			self.xanim.dest = newX
-			self.x = self.xanim:step(dt)
+		if self.pan then
+			self.x, self.y, self.angle = self.pan:step(dt, {newX, newY, newAngle})
 
-			if self.xanim:isDone() then
-				self.xanim = nil
+			if self.pan:isDone() then
+				self.pan = nil
 			end
-		else
-			self.x = newX
-		end
-
-		if self.yanim then
-			self.yanim.dest = newY
-			self.y = self.yanim:step(dt)
-
-			if self.yanim:isDone() then
-				self.yanim = nil
-			end
-		else
-			self.y = newY
-		end
-
-		if self.aanim then
-			self.aanim.dest = newAngle
-			self.angle = self.aanim:step(dt)
-
-			if self.aanim:isDone() then
-				self.aanim = nil
-			end
-		else
-			self.angle = newAngle
 		end
 	end
 end

--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -215,6 +215,7 @@ function InGame.update(dt)
 		player.menuOpen = menuOpen
 
 		player:handleInput()
+		player:update(dt)
 	end
 
 	if closeMenu then

--- a/src/player.lua
+++ b/src/player.lua
@@ -24,6 +24,10 @@ function Player.create(world, controls, ship, camera)
 			self.camera:setTarget(self.selected.structure.body)
 		end)
 
+		self.selected:whenDoneBuildingOnStructure(function()
+			self.camera:setTarget(self.ship.body)
+		end)
+
 		local corePart = ship.corePart
 		if corePart then
 			self.camera.hud:setCommand(corePart:getCommand())
@@ -149,10 +153,6 @@ function Player:buttonreleased(source, button)
 end
 
 function Player:draw(debugmode)
-	-- if self.ship and not self.selected:isBuildingOnStructure() then
-	-- 	self.camera:setTarget(self.ship.body)
-	-- end
-
 	self.camera:drawPlayer(self, debugmode)
 end
 

--- a/src/player.lua
+++ b/src/player.lua
@@ -19,7 +19,11 @@ function Player.create(world, controls, ship, camera)
 	if ship then
 		self.camera.body = ship.body
 		self.selected = Selection.create(world, self.ship.corePart:getTeam(), self.camera)
-		
+
+		self.selected:whenBuildingOnStructure(function()
+			self.camera:setTarget(self.selected.structure.body)
+		end)
+
 		local corePart = ship.corePart
 		if corePart then
 			self.camera.hud:setCommand(corePart:getCommand())
@@ -145,13 +149,11 @@ function Player:buttonreleased(source, button)
 end
 
 function Player:draw(debugmode)
-	if self.ship then
-		if self.selected:isBuildingOnStructure() then
-			self.camera.body = self.selected.structure.body
-		else
-			self.camera.body = self.ship.body
-		end
-	end
+	-- if self.ship then
+	-- 	else
+	-- 		self.camera:setTarget(self.ship.body)
+	-- 	end
+	-- end
 
 	self.camera:drawPlayer(self, debugmode)
 end

--- a/src/player.lua
+++ b/src/player.lua
@@ -149,10 +149,8 @@ function Player:buttonreleased(source, button)
 end
 
 function Player:draw(debugmode)
-	-- if self.ship then
-	-- 	else
-	-- 		self.camera:setTarget(self.ship.body)
-	-- 	end
+	-- if self.ship and not self.selected:isBuildingOnStructure() then
+	-- 	self.camera:setTarget(self.ship.body)
 	-- end
 
 	self.camera:drawPlayer(self, debugmode)

--- a/src/player.lua
+++ b/src/player.lua
@@ -151,6 +151,10 @@ function Player:buttonreleased(source, button)
 	end
 end
 
+function Player:update(dt)
+	self.camera:update(dt)
+end
+
 function Player:draw(debugmode)
 	self.camera:drawPlayer(self, debugmode)
 end

--- a/src/player.lua
+++ b/src/player.lua
@@ -222,7 +222,7 @@ function Player:buttonreleased(source, button)
 end
 
 function Player:update(dt)
-	self.camera:update(dt)
+	self.camera:update(self, dt)
 end
 
 function Player:draw(debugmode)

--- a/src/selection.lua
+++ b/src/selection.lua
@@ -20,6 +20,7 @@ function Selection.create(world, team)
 	self.assign = nil
 
 	self.buildingOnStructureListeners = {}
+	self.doneBuildingOnStructureListeners = {}
 
 	return self
 end
@@ -99,6 +100,7 @@ function Selection:released(cursorX, cursorY)
 					build:setSide(partSide)
 					if build.mode == 5 then
 						self.build = nil
+						self:signalDoneBuildingOnStructure()
 					end
 				else
 					self.build = nil
@@ -135,6 +137,16 @@ end
 
 function Selection:signalBuildingOnStructure()
 	for _, func in ipairs(self.buildingOnStructureListeners) do
+		func()
+	end
+end
+
+function Selection:whenDoneBuildingOnStructure(func)
+	table.insert(self.doneBuildingOnStructureListeners, func)
+end
+
+function Selection:signalDoneBuildingOnStructure()
+	for _, func in ipairs(self.doneBuildingOnStructureListeners) do
 		func()
 	end
 end

--- a/src/selection.lua
+++ b/src/selection.lua
@@ -19,6 +19,8 @@ function Selection.create(world, team)
 
 	self.assign = nil
 
+	self.buildingOnStructureListeners = {}
+
 	return self
 end
 
@@ -40,6 +42,7 @@ function Selection:pressed(cursorX, cursorY, order)
 							self.part = nil
 							self.build = nil
 						end
+						self:signalBuildingOnStructure()
 					end
 				end
 			elseif order == "destroy" then
@@ -122,8 +125,15 @@ function Selection:released(cursorX, cursorY)
 	end
 end
 
-function Selection:isBuildingOnStructure()
-	return self.build and self.build.structure
+function Selection:whenBuildingOnStructure(func)
+	table.insert(self.buildingOnStructureListeners, func)
+	-- return self.build and self.build.structure
+end
+
+function Selection:signalBuildingOnStructure()
+	for _, func in ipairs(self.buildingOnStructureListeners) do
+		func()
+	end
 end
 
 return Selection

--- a/src/selection.lua
+++ b/src/selection.lua
@@ -125,9 +125,12 @@ function Selection:released(cursorX, cursorY)
 	end
 end
 
+function Selection:isBuildingOnStructure()
+	return self.build and self.build.structure
+end
+
 function Selection:whenBuildingOnStructure(func)
 	table.insert(self.buildingOnStructureListeners, func)
-	-- return self.build and self.build.structure
 end
 
 function Selection:signalBuildingOnStructure()


### PR DESCRIPTION
When connecting a part to a structure, the camera moves to that structure while doing the build action. Now that camera movement is linearly interpolated.

This is more work on #351.

Issues:
- [x] The camera never moves back after building
- [ ] I'm not sure about the hacky event system; it's just a quick thing I added to solve the problem
- [x] Code cleanup, commented code, etc.
- [x] Probably doesn't need a lume dependency
- [x] The animation speed is dependent of frame rate
- [x] Angles are not bounded to 0-360 degrees
- [x] The linear interpolation is from current position to target position instead of from starting position to target position. This makes the animation look nonlinear and go faster than expected.