### PR TITLE
Fix camera position updating

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -347,6 +347,8 @@ function Camera:update(player, dt)
 			if self.pan:isDone() then
 				self.pan = nil
 			end
+		else
+			self.x, self.y, self.angle = newX, newY, newAngle
 		end
 	end
 end


### PR DESCRIPTION
A bug was introduced late in f209195 that caused camera movement to be frozen when an animation was not in progress. Now the camera always follows its set target as it should.