### PR TITLE
Fix tests

### DIFF
--- a/test/test_all_scenes.sh
+++ b/test/test_all_scenes.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 
 find src/res/scenes -name '*.txt' | sed -E 's|.*/([[:alnum:]_-]+).txt|\1|' | while IFS= read -r scene; do
-	if ! output=$(echo "quit()" | love src $extra_args --scene "$scene" 2>&1)
+	if ! output=$(echo "quit()" | love src $extra_args --scene="$scene" 2>&1)
 	then
 		printf "FAILED: scene %s crashed:\n%s\n" "$scene" "$output"
 		exit 1

--- a/test/test_breakage.sh
+++ b/test/test_breakage.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene test-breakage > "$output" <<EOF
+love src $extra_args --scene=test-breakage > "$output" <<EOF
 return #world.objects
 sleep(2)
 return #world.objects

--- a/test/test_disconnect_parts.sh
+++ b/test/test_disconnect_parts.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene test-disconnect-parts > "$output" <<EOF
+love src $extra_args --scene=test-disconnect-parts > "$output" <<EOF
 return #world.objects
 world.objects[2]:disconnectPart({1,-1})
 return #world.objects

--- a/test/test_disconnect_parts_from_active_ship.sh
+++ b/test/test_disconnect_parts_from_active_ship.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene test-disconnect-parts-from-active-ship > "$output" <<EOF
+love src $extra_args --scene=test-disconnect-parts-from-active-ship > "$output" <<EOF
 return #world.objects
 world.objects[2]:disconnectPart({1,-1})
 return #world.objects

--- a/test/test_heal.sh
+++ b/test/test_heal.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene test-general1 > "$output" 2>/dev/null <<EOF
+love src $extra_args --scene=test-general1 > "$output" 2>/dev/null <<EOF
 players[1].ship.corePart.modules.hull.health = 1
 timer = players[1].ship.corePart.modules.heal.timer
 timer.time = 0.1

--- a/test/test_missile_area_of_effect.sh
+++ b/test/test_missile_area_of_effect.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene test-missile2 > "$output" <<EOF
+love src $extra_args --scene=test-missile2 > "$output" <<EOF
 return #world.objects
 sleep(2)
 return #world.objects

--- a/test/test_spawn.sh
+++ b/test/test_spawn.sh
@@ -3,7 +3,7 @@
 extra_args="$1"
 output="$2"
 
-love src $extra_args --scene startScene > "$output" <<EOF
+love src $extra_args --scene=startScene > "$output" <<EOF
 return #world.objects
 debugmode.on = true
 debugmode.spawn = true


### PR DESCRIPTION
We used to support `--scene blah` and `--scene=blah`, but recently I removed to the first one to simplify the code. All the tests used that first syntax, so they stopped working.