### PR TITLE
Fix bug where pan animation angle

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -16,6 +16,7 @@ function Camera.create()
 	self.x = 0
 	self.y = 0
 	self.angle = 0
+	self.angleFixed = true
 	self.zoomInt = 8
 	self:adjustZoom(0)
 	self.scissor = {x = 0, y = 0, width = 0, height = 0}
@@ -32,7 +33,7 @@ end
 function Camera:setTarget(target)
 	local duration = 1
 	local x, y = self.body:getPosition()
-	local angle = self.body:getAngle()
+	local angle = self.angleFixed and 0 or self.body:getAngle()
 
 	self.body = target
 	self.pan = Animation({x, y, angle}, {target:getX(), target:getY(), target:getAngle()}, duration, "linear")
@@ -335,7 +336,7 @@ function Camera:update(player, dt)
 		local newX, newY = self.body:getPosition()
 		local newAngle = shortestPath(
 			self.angle,
-			player.isCameraAngleFixed and 0 or self.body:getAngle() % (2*math.pi)
+			self.angleFixed and 0 or self.body:getAngle() % (2*math.pi)
 		)
 
 		if self.pan then

--- a/src/player.lua
+++ b/src/player.lua
@@ -44,7 +44,6 @@ function Player.create(world, controls, ship, camera)
 	self.selectionKeyDown = false
 	self.isBuilding = false
 	self.isRemoving = false
-	self.isCameraAngleFixed = true
 	self.partX = nil
 	self.partY = nil
 	self.cursorX = 0
@@ -93,7 +92,7 @@ function Player:cursorpressed(cursor, control, debugmodeEnabled)
 		if control.ship == "health" then
 			self.showHealth = not self.showHealth
 		elseif control.ship == "cameraRotate" then
-			self.isCameraAngleFixed = not self.isCameraAngleFixed
+			self.camera.angleFixed = not self.camera.angleFixed
 			
 		elseif control.ship == "build" or control.ship == "destroy" then
 				local cursorX, cursorY = self.camera:getWorldCoords(
@@ -144,7 +143,7 @@ function Player:pressed(control, debugmodeEnabled)
 			elseif control.ship == "health" then
 				self.showHealth = not self.showHealth
 			elseif control.ship == "cameraRotate" then
-				self.isCameraAngleFixed = not self.isCameraAngleFixed
+				self.camera.angleFixed = not self.camera.angleFixed
 			end
 		elseif control.menu then
 			self.camera.hud:pressed(control)


### PR DESCRIPTION
Pan animations would rotate to the player's body, even when the camera was in fixed angle mode. Now pan animations correctly start at angle 0 if fixed mode is active.

Also, refactor Player.isCameraAngleFixed to Camera.angleFixed. This should be a property of the camera, not the player.