### PR TITLE
tools/analyzeDrawTimes: Simplify and clarify x axis ticks

### DIFF
--- a/tools/analyzeDrawTimes/conf.lua
+++ b/tools/analyzeDrawTimes/conf.lua
@@ -5,8 +5,8 @@ function love.conf(t)
 
 	t.window.title = "Synthein - Draw Times"
 	t.window.icon = "tools.png"
-	t.window.width = 800
-	t.window.height = 600
+	t.window.width = 640
+	t.window.height = 480
 	t.window.borderless = false
 	t.window.resizable = false
 	t.window.fullscreen = false

--- a/tools/analyzeDrawTimes/main.lua
+++ b/tools/analyzeDrawTimes/main.lua
@@ -7,6 +7,7 @@ local nBuckets = 20
 local lastLoad = 0
 local times = {}
 local max
+local font = love.graphics.setNewFont(10)
 
 local function reload()
   times = {}
@@ -52,7 +53,6 @@ function love.draw()
   end
 
   -- Draw bars
-  local font = love.graphics.getFont()
   for i = 1, nBuckets do
     local v = buckets[i] or 0
     local w = chartWidth / nBuckets

--- a/tools/analyzeDrawTimes/main.lua
+++ b/tools/analyzeDrawTimes/main.lua
@@ -6,20 +6,18 @@ local nBuckets = 20
 -- State
 local lastLoad = 0
 local times = {}
-local max = 0
-local min = math.huge
+local max
 
 local function reload()
   times = {}
   max = 0
-  min = math.huge
 
   for time in love.filesystem.lines(logfile) do
     local time = tonumber(time)
     table.insert(times, time)
     max = math.max(max, time)
-    min = math.min(min, time)
   end
+
 end
 
 function love.load()
@@ -35,15 +33,15 @@ function love.update(dt)
 end
 
 function love.draw()
-  local chartWidth = love.graphics.getWidth() - margin
-  local chartHeight = love.graphics.getHeight() - margin
+  local chartWidth = love.graphics.getWidth() - margin * 2
+  local chartHeight = love.graphics.getHeight() - margin * 2
 
   love.graphics.print("Number of frames", 10, love.graphics.getHeight()/2, -math.pi/2)
-  love.graphics.print("Duration of frame (ms)", love.graphics.getWidth()/2, chartHeight + 30)
+  love.graphics.print("Duration of frame (ms)", love.graphics.getWidth()/2, love.graphics.getHeight() - 20)
 
   local buckets = {}
   for _, v in ipairs(times) do
-    local bucketIndex = 1 + math.floor((v - min) / (max - min) * (nBuckets-1))
+    local bucketIndex = math.ceil(v / max * nBuckets)
     local oldCount = buckets[bucketIndex] or 0
     buckets[bucketIndex] = oldCount + 1
   end
@@ -53,24 +51,33 @@ function love.draw()
     tallestBar = math.max(tallestBar, buckets[i] or 0)
   end
 
+  -- Draw bars
   local font = love.graphics.getFont()
   for i = 1, nBuckets do
     local v = buckets[i] or 0
     local w = chartWidth / nBuckets
-    local h = v / tallestBar * (chartHeight - margin)
+    local h = v / tallestBar * chartHeight
     local x = margin + (i-1)*w
-    love.graphics.rectangle("fill", x, chartHeight, w, -h)
+    local y = margin + chartHeight
+
+    love.graphics.rectangle("fill", x, y, w, -h)
 
     local label = tostring(tonumber(v))
     local textWidth = font:getWidth(label)
-    love.graphics.print(label, x + (w - textWidth)/2, chartHeight-h-20)
+    love.graphics.print(label, x + (w - textWidth)/2, y-h-20)
 
-    if i % 2 == 0 then
-      label = string.format("%0.1f", min+i*(max-min)/nBuckets*1000)
-      textWidth = font:getWidth(label)
-      love.graphics.line(x + w/2, chartHeight, x + w/2, chartHeight+10)
-      love.graphics.print(label, x + (w - textWidth)/2, chartHeight+10)
-    end
+  end
+
+  -- Draw tick marks
+  for i = 0, nBuckets do
+    local w = chartWidth / nBuckets
+    local x = margin + i * w
+    local y = margin + chartHeight
+    local label = string.format("%0.1f", i*max/nBuckets*1000)
+    local textWidth = font:getWidth(label)
+
+    love.graphics.line(x, y, x, y+10)
+    love.graphics.print(label, x - textWidth/2, y+10)
   end
 end
 


### PR DESCRIPTION
- Always set 0 as the minimum of the chart. This removes the need to search for the minimum value in the input and scale to the minimum.
- Draw the tick marks between bars. A bar is a range of values. The boundaries are more interesting than the middle.

![image](https://github.com/user-attachments/assets/15dfd8e5-235d-4f2e-8dd6-5bf63ac36d47)
