### PR TITLE
Fix tests

### DIFF
--- a/src/debugmode.lua
+++ b/src/debugmode.lua
@@ -28,7 +28,6 @@ function Debug:getSpawn()
 end
 
 function Debug:update(dt)
-	self.drawTimeLogger:update()
 end
 
 function Debug:draw()
@@ -71,6 +70,8 @@ function Debug:draw()
 		local y = math.floor(love.graphics.getHeight() - t*1000)
 		love.graphics.points(i, y)
 	end
+
+	self.drawTimeLogger:log()
 
 	love.graphics.print(
 		string.format("%07.3f fps", love.timer.getFPS()),

--- a/src/drawTimeLogger.lua
+++ b/src/drawTimeLogger.lua
@@ -13,23 +13,24 @@ function DrawTimeLogger.create(capacity, logfile)
   return self
 end
 
-local interval = 30
-function DrawTimeLogger:update(dt)
-	self.frameCount = self.frameCount + 1
-	if self.frameCount % interval == 0 then
-		love.filesystem.append(
-			self.logfile,
-			table.concat(table.move(self.times, #self.times-interval, interval, 1), "\n") .. "\n"
-		)
-	end
-end
-
 function DrawTimeLogger:insert(duration)
 	if #self.times == self.capacity then
 		table.remove(self.times, 1)
 	end
 
 	table.insert(self.times, duration)
+end
+
+local interval = 30
+function DrawTimeLogger:log()
+	self.frameCount = self.frameCount + 1
+
+	if self.frameCount % interval == 0 then
+		love.filesystem.append(
+			self.logfile,
+			table.concat(self.times, "\n", #self.times-interval + 1, #self.times) .. "\n"
+		)
+	end
 end
 
 function DrawTimeLogger:average()

--- a/src/tests/test_inGame.lua
+++ b/src/tests/test_inGame.lua
@@ -1,11 +1,11 @@
 local InGame = require("gamestates/inGame")
-local Screen = require("screen")
+
+local stub = require("tests/stub")
 
 local t = {}
 
 function t.test_screen_resize_should_not_crash()
-	local screen = Screen()
-	InGame.load("test-general1", {}, false)
+	InGame.load("test-general1", {}, false, stub())
 	InGame.resize(100, 100)
 end
 


### PR DESCRIPTION
- Add a missing argument to InGame.Load() in a test
- Fix faulty DrawTimeLogger logic
  - DrawTimeLogger used to increment the number of frames in update(); it can't know the number of frames in update() because update() and draw() can happen at different rates.
  - When logging the most recent 30 frames to a file, it used to do something that didn't make sense. It would copy the newest frame times to the end of the list of frame times, overwriting some of the times. Now we simply write the last 30 frame times without copying anything.

    The logging code also used to have an off-by-one error where we would try to write a nil value to the frame time log if debug mode was turned on right away at the start of the game.