### PR TITLE
Don't overflow the frame number

### DIFF
--- a/src/draw_time_logger.rs
+++ b/src/draw_time_logger.rs
@@ -9,7 +9,7 @@ pub struct DrawTimeLogger {
     pub times: Vec<f64>,
     pub capacity: usize,
     pub log_file: Option<fs::File>,
-    pub frame_num: u8,
+    pub frame_num: u64,
 }
 
 pub fn new(capacity: usize, logdir: String, logfile: String) -> Result<DrawTimeLogger> {
@@ -37,7 +37,7 @@ pub fn new(capacity: usize, logdir: String, logfile: String) -> Result<DrawTimeL
     })
 }
 
-const INTERVAL: u8 = 30;
+const INTERVAL: u64 = 30;
 
 impl DrawTimeLogger {
     pub fn insert(&mut self, duration: f64) {


### PR DESCRIPTION
I think I set this to a u8 originally because I wanted to let it roll over frequently? I'm not really sure what I was thinking, but in any case this u8 overflows after a few seconds and crashes the game because Rust has an assertion that catches it.

I didn't notice this before because Rust compiles out the assertion in release mode. We switched to debug mode in ef3be146.