### PR TITLE
Remove the player's reference to world

### DIFF
--- a/src/camera.lua
+++ b/src/camera.lua
@@ -187,11 +187,11 @@ function Camera:resetTarget()
 	self:setTarget(self.defaultBody)
 end
 
-function Camera:spawnPart(part)
+function Camera:spawnPart(partChar)
 	self.world.info.create(
 		"structure",
 		{self.x, self.y + 5},
-		PartRegistry.createPart(part)
+		PartRegistry.createPart(partChar)
 	)
 end
 

--- a/src/camera.lua
+++ b/src/camera.lua
@@ -370,16 +370,15 @@ function Camera:drawWorldObjects(player, debugmode)
 		fixtureList[PhysicsReferences.categories[c]] = {}
 	end
 
-	local function callback(fixture)
-		local category = fixture:getFilterData()
-		if fixtureList[category] then
-			table.insert(fixtureList[category], fixture)
-		end
-		return true
-	end
-
 	local a, b, c, d = self:getAABB()
-	self.world.physics:queryBoundingBox(a, b, c, d, callback)
+	self.world.physics:queryBoundingBox(a, b, c, d, function(fixture)
+			local category = fixture:getFilterData()
+			if fixtureList[category] then
+				table.insert(fixtureList[category], fixture)
+			end
+			return true
+		end
+	)
 
 	endTime = love.timer.getTime()
 	duration = endTime - startTime

--- a/src/camera.lua
+++ b/src/camera.lua
@@ -1,5 +1,6 @@
 local Animation = require("animation")
 local Hud = require("hud")
+local PartRegistry = require("world/shipparts/partRegistry")
 local PhysicsReferences = require("world/physicsReferences")
 local Settings = require("settings")
 local log = require("log")
@@ -13,6 +14,7 @@ function Camera.create(world, team, defaultBody)
 	local self = {}
 	setmetatable(self, Camera)
 
+	self.world = world
 	self.defaultBody = defaultBody
 	self.body = defaultBody
 	self.x = 0
@@ -183,6 +185,14 @@ end
 
 function Camera:resetTarget()
 	self:setTarget(self.defaultBody)
+end
+
+function Camera:spawnPart(part)
+	self.world.info.create(
+		"structure",
+		{self.x, self.y + 5},
+		PartRegistry.createPart(part)
+	)
 end
 
 function Camera:getWorldCoords(cursorX, cursorY)
@@ -368,9 +378,8 @@ function Camera:drawWorldObjects(player, debugmode)
 		return true
 	end
 
-	local a, b, c, d = player.camera:getAABB()
-	player.world.physics:queryBoundingBox(a, b, c, d, callback)
-
+	local a, b, c, d = self:getAABB()
+	self.world.physics:queryBoundingBox(a, b, c, d, callback)
 
 	endTime = love.timer.getTime()
 	duration = endTime - startTime

--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -85,7 +85,7 @@ function InGame.load(scene, playerHostility, saveName, debuginfo)
 	world.physics:update(0)
 
 	if #players == 0 then
-		table.insert(players, Player.create(Controls(), nil, screen:createViewPort()))
+		table.insert(players, Player.create(Controls(), nil, screen:createViewPort(world)))
 	end
 
 	saveMenu = SaveMenu(Settings.saveDir, saveName)

--- a/src/gamestates/inGame.lua
+++ b/src/gamestates/inGame.lua
@@ -68,14 +68,14 @@ function InGame.load(scene, playerHostility, saveName, debuginfo)
 		if i == 1 then
 			table.insert(
 				players,
-				Player.create(world, Controls(), ship, screen:createViewPort(world, ship.body:getUserData().team, ship.body))
+				Player.create(Controls(), ship, screen:createViewPort(world, ship.body:getUserData().team, ship.body))
 			)
 		else
 			local joystick = love.joystick.getJoysticks()[#players]
 			if joystick then
 				table.insert(
 					players,
-					Player.create(world, Controls(joystick), ship, screen:createViewPort())
+					Player.create(Controls(joystick), ship, screen:createViewPort(world, ship.body:getUserData().team, ship.body))
 				)
 			end
 		end
@@ -85,7 +85,7 @@ function InGame.load(scene, playerHostility, saveName, debuginfo)
 	world.physics:update(0)
 
 	if #players == 0 then
-		table.insert(players, Player.create(world, Controls(), nil, screen:createViewPort()))
+		table.insert(players, Player.create(Controls(), nil, screen:createViewPort()))
 	end
 
 	saveMenu = SaveMenu(Settings.saveDir, saveName)

--- a/src/player.lua
+++ b/src/player.lua
@@ -1,14 +1,12 @@
 local PartSelector = require("widgets/partSelector")
-local PartRegistry = require("world/shipparts/partRegistry")
 
 local Player = {}
 Player.__index = Player
 
-function Player.create(world, controls, ship, viewPort)
+function Player.create(controls, ship, viewPort)
 	local self = {}
 	setmetatable(self, Player)
 
-	self.world = world
 	self.controls = controls
 	self.ship = ship
 	self.viewPort = viewPort
@@ -99,11 +97,7 @@ function Player:pressed(control, debugmodeEnabled)
 		elseif control.menu == "confirm" then
 			local part = self.partSelector:pressed(control)
 			if part then
-				local camera = self.camera
-				self.world.info.create(
-					"structure",
-					{camera.x, camera.y + 5},
-					PartRegistry.createPart(part))
+				self.camera:spawnPart(part)
 			end
 			self.menu = nil
 		end
@@ -140,11 +134,7 @@ function Player:buttonpressed(source, button, debugmode)
 		elseif menuButton == "confirm" then
 			local part = self.partSelector:keypressed("return")
 			if part then
-				local camera = self.camera
-				self.world.info.create(
-					"structure",
-					{camera.x, camera.y + 5},
-					PartRegistry.createPart(part))
+				self.camera:spawnPart(part)
 			end
 			self.menu = nil
 		end


### PR DESCRIPTION
Player only used the world for one thing: spawning in parts in creative mode. That can live in the camera for now, but we would like to move it to the HUD.

<img width="383" height="707" alt="world" src="https://github.com/user-attachments/assets/a13b1c7c-7d6e-47aa-8c0b-2c4ae00390d0" />

