### PR TITLE
Fix crash when removing a part from a drone

### DIFF
--- a/src/world/shipparts/modules/drone.lua
+++ b/src/world/shipparts/modules/drone.lua
@@ -39,9 +39,9 @@ function Drone:getOrders(worldInfo, leader, droneBody, bodyList, capabilities)
 				else
 					self.assignment = command:getAssignment(id)
 				end
-				
+
 				local position = command:getPosition(self.assignment)
-				
+
 				--local fixedAngle = true
 				if fixedAngle then
 					destination = {Location.bodyCenter6(leaderBody)}
@@ -96,7 +96,7 @@ function Drone:getOrders(worldInfo, leader, droneBody, bodyList, capabilities)
 
 				local mSq = (dx * dx) + (dy * dy)
 				local mVSq = (dvx * dvx) + (dvy * dvy)
-				
+
 				-- CollisionMetric ~ path alignment / time to collision
 				local collisionMetric = -(dx * dvx + dy * dvy) / mSq
 
@@ -104,25 +104,25 @@ function Drone:getOrders(worldInfo, leader, droneBody, bodyList, capabilities)
 				if collisionMetric > 0.2 then
 					local directX = - dx
 					local directY = - dy
-					
+
 					local dodgeX = -dvy
 					local dodgeY = dvx
-					
+
 					if dx*dvy < dy*dvx then
 						dodgeX = -dodgeX
 						dodgeY = -dodgeY
 					end
-					
+
 					local invDodgeMetric = 25 / (mVSq + 25)
-					
+
 					local combinedX = invDodgeMetric * directX + (1-invDodgeMetric) * dodgeX
 					local combinedY = invDodgeMetric * directY + (1-invDodgeMetric) * dodgeY
-					
+
 					local scaleFactor = collisionMultiplier * collisionMetric
 					sepX = sepX + combinedX * scaleFactor
 					sepY = sepY + combinedY * scaleFactor
 				end
-				
+
 				--TODO add spacing logic here.
 				if object.type == "structure" then
 					if teamHostility:test(self.team, object.team or 0) then
@@ -188,7 +188,7 @@ function Drone:getOrders(worldInfo, leader, droneBody, bodyList, capabilities)
 			target[6] = 0
 			m = 1 - dsq/targetMSq
 		end
-	elseif self.repairFixture then
+	elseif self.repairFixture and capabilities.repair then
 		-- Move close to repair blocks
 		local fixture = self.repairFixture
 		local body = fixture:getBody()


### PR DESCRIPTION
If a drone was busy repairing something, removing its repair part would crash the game:

	Error: world/structureMath.lua:68: attempt to index local 'vectorB' (a nil value)
	stack traceback:
		[love "boot.lua"]:352: in function '__index'
		world/structureMath.lua:68: in function 'subtractVectors'
		world/shipparts/modules/drone.lua:225: in function 'getOrders'
		world/structure.lua:406: in function 'command'
		world/structure.lua:466: in function 'update'
		world/world.lua:231: in function 'update'
		gamestates/inGame.lua:308: in function 'update'
		main.lua:200: in function 'update'
		[love "callbacks.lua"]:162: in function <[love "callbacks.lua"]:144>
		[C]: in function 'xpcall'

This is because the drone didn't check whether it had a repair capability or not. As long as it had a target for repair, it would try to repair. Now it will only try to repair if it has a part with repair capability.